### PR TITLE
Define .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+*.rs diff=rust
+Cargo.lock merge=binary
+
+*.ex diff=elixir
+*.exs diff=elixir
+*.erl diff=erlang
+mix.lock merge=binary
+
+*.jar merge=binary


### PR DESCRIPTION
This should help with merge conflicts in the lockfiles, as `merge=binary` will still cause conflict, but will leave merge file as is. This make it easier to resolve such conflict by doing deps update manually afterwards.