### PR TITLE
Add uniffi-bindgen crate for bindgen CLI execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,6 @@ jobs:
             target/            
           key: 1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-    
-      - name: Install uniffi_bindgen
-        uses: taiki-e/cache-cargo-install-action@v1
-        with:
-          tool: uniffi_bindgen@0.22.0
 
       - name: 🔨 Build
         run: cargo build --verbose

--- a/README.md
+++ b/README.md
@@ -72,3 +72,11 @@ sudo apt-get install python3.x # 3.8, 3.9
 # Docker setup
 
 There is a Docker image for development on emulated system, but at the moment only for M1 - although it's easily configurable for other architectures. We'll make a set of instructions available for it.
+
+# Using the uniffi-bindgen CLI
+
+This project has a dedicated crate for build and run the CLI. You can execute it from any crate root by:
+
+```bash
+cargo run -p uniffi-bindgen
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,4 +54,3 @@ RUN mkdir -p /tmp/setup-jna \
   && rm -rf ./setup-jna
 
 RUN gem install ffi --no-document
-RUN cargo install uniffi_bindgen

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = [
+    # Binary generation crate. Breaks nomenclature to avoid collision with uniffi_bindgen library crate.
+    # See https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html#multi-crate-workspaces
+    "uniffi-bindgen", 
     "uniffi_demo_module",
     "uniffi_backend_keys",
 ]

--- a/lib/uniffi-bindgen/Cargo.toml
+++ b/lib/uniffi-bindgen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uniffi-bindgen"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "./src/uniffi_bindgen.rs"
+
+[dependencies]
+uniffi = {workspace=true, features=["cli"]}

--- a/lib/uniffi-bindgen/src/uniffi_bindgen.rs
+++ b/lib/uniffi-bindgen/src/uniffi_bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main();
+}


### PR DESCRIPTION
The CLI binary cannot be installed anymore with `cargo install uniffi_bindgen`. See [changelog](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#v0230-backend-crates-v0230---2023-01-27).

This is the implementation of the [proposed solution](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html#multi-crate-workspaces).
