### PR TITLE
Add zcash accountprivkey from extended privkey

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
 Luca Campobasso <luca@eiger.co> <lcampobasso@gmail.com>
 Daniel Zduniak <daniel.zduniak@eiger.co> <dzduniak@gmail.com>
 Łukasz Niemier <lukasz@eiger.co> <lukasz@niemier.pl>
+Eloy López <eloy@eiger.co> <eloylp@eloylp.dev>

--- a/lib/uniffi_backend_keys/src/backend_keys.udl
+++ b/lib/uniffi_backend_keys/src/backend_keys.udl
@@ -34,11 +34,20 @@ interface ZcashAccountPrivKey {
   [Name=from_bytes, Throws=ZcashError]
   constructor(sequence<u8> data);
 
+  [Name=from_extended_privkey]
+  constructor(ZcashExtendedPrivKey key);
+
   ZcashAccountPubKey to_account_pubkey();
 
   sequence<u8> to_bytes();
 
   // todo
+};
+
+/* hdwallet::extended_key::ExtendedPrivKey */
+interface ZcashExtendedPrivKey {
+  [Name=with_seed, Throws=ZcashError]
+  constructor(sequence<u8> data);
 };
 
 /* zcash_primitives::legacy::keys::AccountPubKey */

--- a/lib/uniffi_backend_keys/src/bin/test_data.rs
+++ b/lib/uniffi_backend_keys/src/bin/test_data.rs
@@ -1,3 +1,4 @@
+use hdwallet::ExtendedPrivKey;
 use zcash_client_backend::keys::{Era, UnifiedSpendingKey};
 use zcash_primitives::{
     consensus::MainNetwork, legacy::keys::AccountPrivKey, sapling::Diversifier, zip32::Scope,
@@ -46,4 +47,16 @@ fn main() {
     println!("SaplinkIvk PaymentAddress bytes: {address}");
     println!();
     println!("AccountPrivateKey bytes: {apk_bytes}");
+
+    // Obtaining from original API expected byte array results
+    // for derivation from ExtendedPrivKey to AccountPrivKey.
+    let extended_priv_key = ExtendedPrivKey::with_seed(&seed).unwrap();
+    let extended_private_key = AccountPrivKey::from_extended_privkey(extended_priv_key);
+    let extended_private_key_bytes = extended_private_key
+        .to_bytes()
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<String>>()
+        .join(", ");
+    println!("AccountPrivateKey from ExtendedPrivKey bytes: {extended_private_key_bytes}");
 }

--- a/lib/uniffi_backend_keys/src/lib.rs
+++ b/lib/uniffi_backend_keys/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use delegate::delegate;
+use hdwallet::ExtendedPrivKey;
 use zcash_primitives::consensus::{MainNetwork, TestNetwork};
 
 /// Zcash error.
@@ -124,11 +125,15 @@ impl ZcashAccountPrivKey {
         Ok(key.into())
     }
 
-    /*
-    pub fn from_extended_privkey(extprivkey: ZcashExtendedPrivKey) -> Self {
-        todo!()
+    pub fn from_extended_privkey(ext_privkey: Arc<ZcashExtendedPrivKey>) -> Self {
+        let key = zcash_primitives::legacy::keys::AccountPrivKey::from_extended_privkey(
+            ExtendedPrivKey {
+                private_key: ext_privkey.inner.private_key,
+                chain_code: ext_privkey.inner.chain_code.clone(),
+            },
+        );
+        key.into()
     }
-    */
 
     pub fn to_account_pubkey(&self) -> Arc<ZcashAccountPubKey> {
         Arc::new(self.inner.to_account_pubkey().into())
@@ -166,6 +171,26 @@ impl ZcashAccountPrivKey {
         zcash_primitives::legacy::keys::AccountPrivKey::from_bytes(&bytes)
             .map(ZcashAccountPrivKey::from)
             .ok_or(ZcashError::Unknown)
+    }
+}
+
+/// ExtendedPrivKey is used for child key derivation.
+/// See [secp256k1 crate documentation](https://docs.rs/secp256k1) for SecretKey signatures usage.
+pub struct ZcashExtendedPrivKey {
+    inner: hdwallet::extended_key::ExtendedPrivKey,
+}
+
+impl ZcashExtendedPrivKey {
+    fn with_seed(seed: Vec<u8>) -> Result<Self, ZcashError> {
+        let key =
+            hdwallet::extended_key::ExtendedPrivKey::with_seed(&seed).map_err(ZcashError::from)?;
+        Ok(key.into())
+    }
+}
+
+impl From<hdwallet::extended_key::ExtendedPrivKey> for ZcashExtendedPrivKey {
+    fn from(inner: hdwallet::extended_key::ExtendedPrivKey) -> Self {
+        Self { inner }
     }
 }
 

--- a/lib/uniffi_backend_keys/src/lib.rs
+++ b/lib/uniffi_backend_keys/src/lib.rs
@@ -127,10 +127,7 @@ impl ZcashAccountPrivKey {
 
     pub fn from_extended_privkey(ext_privkey: Arc<ZcashExtendedPrivKey>) -> Self {
         let key = zcash_primitives::legacy::keys::AccountPrivKey::from_extended_privkey(
-            ExtendedPrivKey {
-                private_key: ext_privkey.inner.private_key,
-                chain_code: ext_privkey.inner.chain_code.clone(),
-            },
+            ext_privkey.inner.clone(),
         );
         key.into()
     }

--- a/lib/uniffi_backend_keys/tests/kotlin/test.kts
+++ b/lib/uniffi_backend_keys/tests/kotlin/test.kts
@@ -16,7 +16,7 @@ val diversifier = ZcashDiversifier(listOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).map {
 
 val saplingIvkPaymentAddressBytes = listOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 150, 127, 9, 126, 127, 135, 242, 241, 100, 51, 242, 226, 238, 170, 123, 25, 163, 69, 216, 183, 101, 10, 82, 150, 119, 1, 188, 11, 103, 156, 95).map { it.toUByte() };
 
-val accountPrivKeyBytes = listOf(207, 174, 34, 199, 252, 227, 180, 123, 230, 0, 80, 146, 93, 219, 173, 12, 108, 17, 103, 102, 144, 226, 101, 143, 138, 175, 53, 52, 12, 34, 185, 103, 172, 47, 218, 133, 127, 111, 155, 112, 212, 44, 34, 186, 124, 174, 31, 169, 99, 123, 229, 175, 141, 181, 225, 250, 107, 144, 184, 248, 64, 255, 239, 143).map { it.toUByte() }
+val accountPrivKeyBytes = listOf(207, 174, 34, 199, 252, 227, 180, 123, 230, 0, 80, 146, 93, 219, 173, 12, 108, 17, 103, 102, 144, 226, 101, 143, 138, 175, 53, 52, 12, 34, 185, 103, 172, 47, 218, 133, 127, 111, 155, 112, 212, 44, 34, 186, 124, 174, 31, 169, 99, 123, 229, 175, 141, 181, 225, 250, 107, 144, 184, 248, 64, 255, 239, 143).map { it.toUByte() };
 
 val accountPrivKey = ZcashAccountPrivKey.fromSeed(
     ZcashConsensusParameters.MAIN_NETWORK,
@@ -38,3 +38,10 @@ assert(unifiedSpendingKey.toUnifiedFullViewingKey()
 
 // Test ZcashAccountPrivKey.fromSeed
 assert(accountPrivKey.toBytes() == accountPrivKeyBytes)
+
+// Test ZcashExtendedPrivKey.withSeed , ending up in private key.
+val accountExtendedPrivKey = ZcashExtendedPrivKey.withSeed(seed);
+val privkey = ZcashAccountPrivKey.fromExtendedPrivkey(accountExtendedPrivKey);
+// This "golden" array of bytes was obtained from the original API.
+val expected_bytes = listOf(149, 166, 0, 189, 51, 113, 120, 140, 117, 138, 197, 190, 79, 199, 36, 207, 244, 33, 243, 51, 208, 246, 123, 28, 7, 59, 51, 23, 198, 47, 254, 133, 152, 104, 37, 20, 245, 17, 68, 127, 3, 242, 44, 136, 77, 60, 173, 143, 250, 10, 6, 187, 211, 123, 199, 44, 60, 30, 76, 229, 192, 202, 104, 8).map {it.toUByte()};
+assert(privkey.toBytes() == expected_bytes);

--- a/lib/uniffi_backend_keys/tests/python/test.py
+++ b/lib/uniffi_backend_keys/tests/python/test.py
@@ -41,7 +41,13 @@ class Test(unittest.TestCase):
         
     def test_account_priv_key_from_seed(self):
         self.assertEqual(self.account_priv_key.to_bytes(), self.account_priv_key_bytes)
-        
+
+    def test_account_priv_key_from_extended_priv_key(self):
+        accountExtendedPrivKey = ZcashExtendedPrivKey.with_seed(self.seed)
+        privkey = ZcashAccountPrivKey.from_extended_privkey(accountExtendedPrivKey)
+        # This "golden" array of bytes was obtained from the original API.
+        expected_bytes = [149, 166, 0, 189, 51, 113, 120, 140, 117, 138, 197, 190, 79, 199, 36, 207, 244, 33, 243, 51, 208, 246, 123, 28, 7, 59, 51, 23, 198, 47, 254, 133, 152, 104, 37, 20, 245, 17, 68, 127, 3, 242, 44, 136, 77, 60, 173, 143, 250, 10, 6, 187, 211, 123, 199, 44, 60, 30, 76, 229, 192, 202, 104, 8]
+        self.assertEqual(privkey.to_bytes(), expected_bytes)
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/uniffi_backend_keys/tests/ruby/test.rb
+++ b/lib/uniffi_backend_keys/tests/ruby/test.rb
@@ -50,5 +50,12 @@ class TestApk < Test::Unit::TestCase
   def test_account_priv_key_from_seed
     assert_equal(@@account_priv_key.to_bytes(), @@account_priv_key_bytes)
   end
-    
+
+  def test_account_priv_key_from_extended_priv_key
+    accountExtendedPrivKey = BackendKeys::ZcashExtendedPrivKey.with_seed(@@seed)
+    privkey = BackendKeys::ZcashAccountPrivKey.from_extended_privkey(accountExtendedPrivKey)
+    # This "golden" array of bytes was obtained from the original API.
+    expected_bytes = [149, 166, 0, 189, 51, 113, 120, 140, 117, 138, 197, 190, 79, 199, 36, 207, 244, 33, 243, 51, 208, 246, 123, 28, 7, 59, 51, 23, 198, 47, 254, 133, 152, 104, 37, 20, 245, 17, 68, 127, 3, 242, 44, 136, 77, 60, 173, 143, 250, 10, 6, 187, 211, 123, 199, 44, 60, 30, 76, 229, 192, 202, 104, 8].map { |b| [b].pack('c').unpack('c').first }
+    assert_equal(privkey.to_bytes(), expected_bytes)
+  end
 end

--- a/lib/uniffi_backend_keys/tests/swift/test.swift
+++ b/lib/uniffi_backend_keys/tests/swift/test.swift
@@ -38,3 +38,10 @@ assert(unifiedSpendingKey.toUnifiedFullViewingKey()
 
 // Test ZcashAccountPrivKey.fromSeed
 assert(accountPrivKey.toBytes() == accountPrivKeyBytes)
+
+// Test ZcashExtendedPrivKey.withSeed, ending up in a private key.
+let accountExtendedPrivKey = try ZcashExtendedPrivKey.withSeed(data: seed);
+let privkey = ZcashAccountPrivKey.fromExtendedPrivkey(key: accountExtendedPrivKey);
+// This "golden" array of bytes was obtained from the original API.
+let expected_bytes: [UInt8] = [149, 166, 0, 189, 51, 113, 120, 140, 117, 138, 197, 190, 79, 199, 36, 207, 244, 33, 243, 51, 208, 246, 123, 28, 7, 59, 51, 23, 198, 47, 254, 133, 152, 104, 37, 20, 245, 17, 68, 127, 3, 242, 44, 136, 77, 60, 173, 143, 250, 10, 6, 187, 211, 123, 199, 44, 60, 30, 76, 229, 192, 202, 104, 8]
+assert(privkey.toBytes() == expected_bytes);


### PR DESCRIPTION
Adds the ability to obtain a private key from a extended priv key. 