### PR TITLE
complete sapling payment address

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -279,15 +279,48 @@ This is partially defined in `UDL` and `code`.
 
 * Original type: [zcash_primitives::sapling::PaymentAddress](https://docs.rs/zcash_primitives/latest/zcash_primitives/sapling/struct.PaymentAddress.html)
 
-| Object/Method name                 |    Score     |        UDL         |        Code        |       Tests        | Docs  |
-| ---------------------------------- | :----------: | :----------------: | :----------------: | :----------------: | :---: |
-| ZcashPaymentAddress::from_parts()  |              |                    |                    |                    |       |
-| ZcashPaymentAddress::from_bytes()  |              |                    |                    |                    |       |
+| Object/Method name                 |    Score        |        UDL         |        Code        |       Tests        | Docs  |
+| ---------------------------------- | :----------:    | :----------------: | :----------------: | :----------------: | :---: |
+| ZcashPaymentAddress::from_parts()  | :red_circle: |                    |                    |                    |       |
+| ZcashPaymentAddress::from_bytes()  | :red_circle:                |                    |                    |                    |       |
 | ZcashPaymentAddress::to_bytes()    | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: |       |
-| ZcashPaymentAddress::diversifier() |              |                    |                    |                    |       |
-| ZcashPaymentAddress::pk_d()        |              |                    |                    |                    |       |
-| ZcashPaymentAddress::g_d()         |              |                    |                    |                    |       |
-| ZcashPaymentAddress::create_note() |              |                    |                    |                    |       |
+| ZcashPaymentAddress::diversifier() | :red_circle: | :white_check_mark: | :white_check_mark: |                       |  :white_check_mark:     |
+| ZcashPaymentAddress::pk_d()        | :red_circle: | :white_check_mark: | :white_check_mark: |                       |   :white_check_mark:    |
+| ZcashPaymentAddress::create_note() | :red_circle: |  :white_check_mark:| :white_check_mark: |                        |  :white_check_mark:     |
+
+### ZcashSaplingNote
+
+* Original type: [zcash_primitives::sapling::Note](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/sapling/note/struct.Note.html)
+
+| Object/Method name                 |    Score        |        UDL         |        Code        |       Tests        | Docs  |
+| ---------------------------------- | :----------:    | :----------------: | :----------------: | :----------------: | :---: |
+| ZcashSaplingNote::from_parts()  | :red_circle:  | :white_check_mark: | :white_check_mark:  |                    |  :white_check_mark:     |
+| ZcashSaplingNote::recipient()   |                  |                    |                    |                    |       |
+| ZcashSaplingNote::value()       |                  |                    |                    |                    |       |
+| ZcashSaplingNote::rseed()       |                  |                    |                    |                    |       |
+| ZcashSaplingNote::nf()          |                  |                    |                    |                    |       |
+| ZcashSaplingNote::cmu()          |                  |                    |                    |                    |       |
+| ZcashSaplingNote::rcm()          |                  |                    |                    |                    |       |
+| ZcashSaplingNote::generate_or_derive_esk()  |                  |                    |                    |          |       |
+
+
+### ZcashSaplingNoteValue
+
+* Original type: [zcash_primitives::sapling::value::NoteValue](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/sapling/value/struct.NoteValue.html)
+
+| Object/Method name                 |    Score        |        UDL         |        Code        |       Tests        | Docs  |
+| ---------------------------------- | :----------:    | :----------------: | :----------------: | :----------------: | :---: |
+| ZcashSaplingNoteValue::inner()  | :red_circle:  | :white_check_mark: | :white_check_mark:  |                    |  :white_check_mark:     |
+| ZcashSaplingNoteValue::from_raw()  | :red_circle:  | :white_check_mark: | :white_check_mark:  |                    |  :white_check_mark:     |
+
+
+### ZcashSaplingDiversifiedTransmissionKey
+
+* Original type: [zcash_primitives::sapling::keys::DiversifiedTransmissionKey](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/sapling/keys/struct.DiversifiedTransmissionKey.html)
+
+| Object/Method name                 |    Score        |        UDL         |        Code        |       Tests        | Docs  |
+| ---------------------------------- | :----------:    | :----------------: | :----------------: | :----------------: | :---: |
+| ZcashSaplingDiversifiedTransmissionKey::from_parts()  | :red_circle:  | :white_check_mark: | :white_check_mark:  |                    |  :white_check_mark:     |
 
 ### ZcashOrchardSpendingKey
 

--- a/lib/uniffi-zcash/Cargo.toml
+++ b/lib/uniffi-zcash/Cargo.toml
@@ -21,6 +21,7 @@ zcash_primitives = { version = "0.10.0", features = ["transparent-inputs"] }
 zcash_client_backend = { version = "0.7.0", features = ["transparent-inputs", "unstable"] }
 orchard = {version= "0.3.0"}
 secp256k1 = {version = "0.21.3"}
+jubjub = {version = "0.9.0"}
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/lib/uniffi-zcash/src/error.rs
+++ b/lib/uniffi-zcash/src/error.rs
@@ -72,6 +72,12 @@ impl From<String> for ZcashError {
     }
 }
 
+impl From<&str> for ZcashError {
+    fn from(value: &str) -> Self {
+        value.to_string().into()
+    }
+}
+
 impl From<secp256k1::Error> for ZcashError {
     fn from(error: secp256k1::Error) -> Self {
         ZcashError::Secp256k1Error { error }

--- a/lib/uniffi-zcash/src/jubjub/mod.rs
+++ b/lib/uniffi-zcash/src/jubjub/mod.rs
@@ -1,0 +1,37 @@
+use jubjub::Fr;
+
+use crate::{utils::cast_slice, ZcashResult};
+
+/// Represents an element of the scalar field $\mathbb{F}_r$ of the Jubjub elliptic
+/// curve construction.
+// The internal representation of this type is four 64-bit unsigned
+// integers in little-endian order. Elements of Fr are always in
+// Montgomery form; i.e., Fr(a) = aR mod r, with R = 2^256.
+pub struct ZcashJubjubFr(Fr);
+
+impl ZcashJubjubFr {
+    pub fn from_bytes(data: &[u8]) -> ZcashResult<Self> {
+        let casted_data = cast_slice(data)?;
+        let opt: Option<Fr> = Fr::from_bytes(&casted_data).into();
+        match opt {
+            Some(fr) => Ok(fr.into()),
+            None => Err("Error parsing data.".into()),
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
+    }
+}
+
+impl From<Fr> for ZcashJubjubFr {
+    fn from(inner: Fr) -> Self {
+        ZcashJubjubFr(inner)
+    }
+}
+
+impl From<ZcashJubjubFr> for Fr {
+    fn from(value: ZcashJubjubFr) -> Self {
+        value.0
+    }
+}

--- a/lib/uniffi-zcash/src/lib.rs
+++ b/lib/uniffi-zcash/src/lib.rs
@@ -19,6 +19,9 @@ pub use self::zcash_client_backend::*;
 mod zcash_primitives;
 pub use self::zcash_primitives::*;
 
+mod jubjub;
+pub use self::jubjub::*;
+
 mod utils;
 
 #[cfg(feature = "rustler")]

--- a/lib/uniffi-zcash/src/udl/jubjub/fr.udl
+++ b/lib/uniffi-zcash/src/udl/jubjub/fr.udl
@@ -1,0 +1,6 @@
+interface ZcashJubjubFr {
+    [Name=from_bytes, Throws=ZcashError]
+    constructor([ByRef] sequence<u8> data);
+
+    sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/keys/diversified_transmission_key.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/keys/diversified_transmission_key.udl
@@ -1,0 +1,1 @@
+interface ZcashSaplingDiversifiedTransmissionKey {};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/note.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/note.udl
@@ -1,0 +1,16 @@
+interface ZcashSaplingNote {
+    [Name=from_parts, Throws=ZcashError]
+    constructor(ZcashPaymentAddress recipient, ZcashSaplingNoteValue value, ZcashRseed rseed);
+};
+
+interface ZcashSaplingNoteValue {
+    [Name=from_raw]
+    constructor(u64 data);
+    u64 inner();
+};
+
+[Enum]
+interface ZcashRseed {
+    BeforeZip212(sequence<u8> fr_data);
+    AfterZip212(sequence<u8> data);
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/payment_address.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/payment_address.udl
@@ -9,5 +9,10 @@ interface ZcashPaymentAddress {
 
   sequence<u8> to_bytes();
 
-  // todo
+  ZcashDiversifier diversifier();
+
+  ZcashSaplingDiversifiedTransmissionKey pk_d();
+
+  [Throws=ZcashError]
+  ZcashSaplingNote create_note(u64 value, ZcashRseed rseed);
 };

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/keys/diversified_transmission_key.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/keys/diversified_transmission_key.rs
@@ -1,0 +1,9 @@
+use zcash_primitives::sapling::keys::DiversifiedTransmissionKey;
+
+pub struct ZcashSaplingDiversifiedTransmissionKey(DiversifiedTransmissionKey);
+
+impl From<DiversifiedTransmissionKey> for ZcashSaplingDiversifiedTransmissionKey {
+    fn from(inner: DiversifiedTransmissionKey) -> Self {
+        ZcashSaplingDiversifiedTransmissionKey(inner)
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/keys/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/keys/mod.rs
@@ -15,3 +15,6 @@ pub use self::proof_generation_key::*;
 
 mod viewing_key;
 pub use self::viewing_key::*;
+
+mod diversified_transmission_key;
+pub use self::diversified_transmission_key::*;

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/mod.rs
@@ -9,3 +9,6 @@ pub use self::payment_address::*;
 
 mod sapling_ivk;
 pub use self::sapling_ivk::*;
+
+mod value;
+pub use self::value::*;

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/value/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/value/mod.rs
@@ -1,0 +1,2 @@
+mod note;
+pub use self::note::*;

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/value/note.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/value/note.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use zcash_primitives::sapling::{value::NoteValue, Note, Rseed};
+
+use crate::{utils::cast_slice, ZcashError, ZcashJubjubFr, ZcashPaymentAddress, ZcashResult};
+
+pub struct ZcashSaplingNote(Note);
+
+impl ZcashSaplingNote {
+    /// Creates a note from its component parts.
+    ///
+    /// # Caveats
+    ///
+    /// This low-level constructor enforces that the provided arguments produce an
+    /// internally valid `Note`. However, it allows notes to be constructed in a way that
+    /// violates required security checks for note decryption, as specified in
+    /// [Section 4.19] of the Zcash Protocol Specification. Users of this constructor
+    /// should only call it with note components that have been fully validated by
+    /// decrypting a received note according to [Section 4.19].
+    ///
+    /// [Section 4.19]: https://zips.z.cash/protocol/protocol.pdf#saplingandorchardinband
+    pub fn from_parts(
+        recipient: Arc<ZcashPaymentAddress>,
+        value: Arc<ZcashSaplingNoteValue>,
+        rseed: ZcashRseed,
+    ) -> ZcashResult<Self> {
+        Ok(Note::from_parts(
+            recipient.as_ref().into(),
+            (*value).into(),
+            rseed.try_into()?,
+        )
+        .into())
+    }
+}
+
+impl From<Note> for ZcashSaplingNote {
+    fn from(inner: Note) -> Self {
+        ZcashSaplingNote(inner)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ZcashSaplingNoteValue(NoteValue);
+
+impl ZcashSaplingNoteValue {
+    pub fn from_raw(data: u64) -> Self {
+        NoteValue::from_raw(data).into()
+    }
+
+    pub fn inner(&self) -> u64 {
+        self.0.inner()
+    }
+}
+
+impl From<NoteValue> for ZcashSaplingNoteValue {
+    fn from(inner: NoteValue) -> Self {
+        ZcashSaplingNoteValue(inner)
+    }
+}
+
+impl From<ZcashSaplingNoteValue> for NoteValue {
+    fn from(value: ZcashSaplingNoteValue) -> Self {
+        value.0
+    }
+}
+
+pub enum ZcashRseed {
+    /// This expects the data from ZcashJubjubFr,
+    /// which can be obtained by calling ZcashJubjubFr::to_bytes().
+    BeforeZip212 { fr_data: Vec<u8> },
+    AfterZip212 { data: Vec<u8> },
+}
+
+impl TryFrom<ZcashRseed> for Rseed {
+    type Error = ZcashError;
+
+    fn try_from(value: ZcashRseed) -> Result<Self, Self::Error> {
+        match value {
+            ZcashRseed::BeforeZip212 { fr_data } => Ok(Rseed::BeforeZip212(
+                ZcashJubjubFr::from_bytes(fr_data.as_slice())?.into(),
+            )),
+            ZcashRseed::AfterZip212 { data } => {
+                let casted_data = cast_slice(data.as_slice())?;
+                Ok(Rseed::AfterZip212(casted_data))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This aims to complete the sapling payment address implementation.

During this PR, other objects were found. In order to facilitate the review, start by the root object `ZcashPaymentAddress`

Closes #79 