### PR TITLE
Add documentation comments to ZcashUnifiedAddress and ZcashTransparentAddress

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -160,6 +160,45 @@ This is a feature matrix which keeps track of the current state of implementatio
 | ZcashUnifiedFullViewingKey::find_address() -> [ZcashUnifiedAddressAndDiversifierIndex](#zcashunifiedaddressanddiversifierindex)    |              | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | ZcashUnifiedFullViewingKey::default_address() -> [ZcashUnifiedAddressAndDiversifierIndex](#zcashunifiedaddressanddiversifierindex) |              | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 
+### ZcashUnifiedAddress
+
+* Original type: [zcash_client_backend::address::UnifiedAddress](https://docs.rs/zcash_client_backend/latest/zcash_client_backend/address/struct.UnifiedAddress.html)
+
+| Object/Method name                                                                        |    Score     |        UDL         |        Code        |       Tests        |        Docs        |
+| ----------------------------------------------------------------------------------------- | :----------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| ZcashUnifiedAddress::new()                                                                | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashUnifiedAddress::orchard() -> [ZcashOrchardAddress](#zcashorchardaddress)             | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashUnifiedAddress::sapling()-> [ZcashPaymentAddress](#zcashpaymentaddress-sapling)      | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashUnifiedAddress::transparent() -> [ZcashTransparentAddress](#zcashtransparentaddress) | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashUnifiedAddress::decode()                                                             | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashUnifiedAddress::encode()                                                             | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+### ZcashRecipientAddress
+
+* Original type: [zcash_client_backend::address::RecipientAddress](https://docs.rs/zcash_client_backend/latest/zcash_client_backend/address/enum.RecipientAddress.html)
+
+| Object/Method name                           |    Score     |        UDL         |        Code        |       Tests        |        Docs        |
+| -------------------------------------------- | :----------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| ZcashRecipientAddress::shielded()            | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashRecipientAddress::transparent()         | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashRecipientAddress::unified()             | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashRecipientAddress::decode()              | :red_circle: | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
+| ZcashRecipientAddress::encode()              | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+### ZcashTransparentAddress
+
+* Original type: [zcash_primitives::legacy::TransparentAddress](https://docs.rs/zcash_primitives/latest/zcash_primitives/legacy/enum.TransparentAddress.html)
+
+| Object/Method name                             |    Score     |        UDL         |        Code        |       Tests        |        Docs        |
+| ---------------------------------------------- | :----------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| ZcashTransparentAddress::public_key()          | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::script()              | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::decode()              | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::encode()              | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::is_public_key()       | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::is_secret()           | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| ZcashTransparentAddress::to_bytes()            | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
 ### ZcashDiversifiableFullViewingKey (Sapling)
 
 * Original type: [zcash_client_backend::keys::sapling::DiversifiableFullViewingKey](https://docs.rs/zcash_client_backend/latest/zcash_client_backend/keys/sapling/struct.DiversifiableFullViewingKey.html)

--- a/lib/uniffi-zcash/src/udl/zcash_client_backend/address/recipient_address.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_client_backend/address/recipient_address.udl
@@ -1,4 +1,7 @@
 interface ZcashRecipientAddress {
+  [Name=decode, Throws=ZcashError]
+  constructor(ZcashConsensusParameters params, [ByRef] string address);
+
   [Name=shielded]
   constructor(ZcashPaymentAddress addr);
 

--- a/lib/uniffi-zcash/src/udl/zcash_client_backend/address/unified_address.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_client_backend/address/unified_address.udl
@@ -1,13 +1,19 @@
 interface ZcashUnifiedAddress {
-  [Name=parse, Throws=ZcashError]
+  [Throws=ZcashError]
+  constructor(
+    ZcashOrchardAddress? orchard,
+    ZcashPaymentAddress? sapling,
+    ZcashTransparentAddress? transparent
+  );
+
+  [Name=decode, Throws=ZcashError]
   constructor(ZcashConsensusParameters params, [ByRef] string address);
 
-  [Throws=ZcashError]
-  constructor(ZcashOrchardAddress? orchard, ZcashPaymentAddress? sapling, ZcashTransparentAddress? transparent);
-
   ZcashOrchardAddress? orchard();
+
   ZcashPaymentAddress? sapling();
+
   ZcashTransparentAddress? transparent();
 
-  string to_string(ZcashConsensusParameters params);
+  string encode(ZcashConsensusParameters params);
 };

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/legacy/transparent_address.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/legacy/transparent_address.udl
@@ -1,12 +1,12 @@
 interface ZcashTransparentAddress {
-  [Name=parse, Throws=ZcashError]
-  constructor(ZcashConsensusParameters params, [ByRef] string input);
-
   [Name=public_key, Throws=ZcashError]
   constructor(sequence<u8> data);
 
   [Name=script, Throws=ZcashError]
   constructor(sequence<u8> data);
+
+  [Name=decode, Throws=ZcashError]
+  constructor(ZcashConsensusParameters params, [ByRef] string input);
 
   string encode(ZcashConsensusParameters params);
 

--- a/lib/uniffi-zcash/src/zcash_client_backend/address/recipient_address.rs
+++ b/lib/uniffi-zcash/src/zcash_client_backend/address/recipient_address.rs
@@ -2,8 +2,12 @@ use std::sync::Arc;
 
 use zcash_client_backend::address::RecipientAddress;
 
-use crate::{ZcashPaymentAddress, ZcashTransparentAddress, ZcashUnifiedAddress};
+use crate::{
+    ZcashConsensusParameters, ZcashError, ZcashPaymentAddress, ZcashResult,
+    ZcashTransparentAddress, ZcashUnifiedAddress,
+};
 
+/// An address that funds can be sent to.
 #[derive(Clone)]
 pub enum ZcashRecipientAddress {
     Shielded(Arc<ZcashPaymentAddress>),
@@ -54,6 +58,12 @@ impl ZcashRecipientAddress {
 
     pub fn unified(addr: Arc<crate::ZcashUnifiedAddress>) -> Self {
         ZcashRecipientAddress::Unified(addr)
+    }
+
+    pub fn decode(params: ZcashConsensusParameters, address: &str) -> ZcashResult<Self> {
+        RecipientAddress::decode(&params, address)
+            .map(From::from)
+            .ok_or::<ZcashError>("unable to parse address".into())
     }
 
     pub fn encode(&self, params: crate::ZcashConsensusParameters) -> String {

--- a/lib/uniffi-zcash/src/zcash_client_backend/address/unified_address.rs
+++ b/lib/uniffi-zcash/src/zcash_client_backend/address/unified_address.rs
@@ -7,6 +7,7 @@ use crate::{
     ZcashTransparentAddress,
 };
 
+/// A Unified Address.
 #[derive(Clone)]
 pub struct ZcashUnifiedAddress(UnifiedAddress);
 
@@ -23,6 +24,10 @@ impl From<ZcashUnifiedAddress> for UnifiedAddress {
 }
 
 impl ZcashUnifiedAddress {
+    /// Constructs a Unified Address from a given set of receivers.
+    ///
+    /// Returns `None` if the receivers would produce an invalid Unified Address (namely,
+    /// if no shielded receiver is provided).
     pub fn new(
         orchard: Option<Arc<ZcashOrchardAddress>>,
         sapling: Option<Arc<ZcashPaymentAddress>>,
@@ -37,23 +42,27 @@ impl ZcashUnifiedAddress {
             .ok_or(ZcashError::Unknown)
     }
 
-    pub fn parse(params: ZcashConsensusParameters, addr: &str) -> ZcashResult<Self> {
-        Ok(AddressCodec::decode(&params, addr).map(ZcashUnifiedAddress)?)
-    }
-
-    pub fn to_string(&self, params: ZcashConsensusParameters) -> String {
-        self.0.encode(&params)
-    }
-
+    /// Returns the Orchard receiver within this Unified Address, if any.
     pub fn orchard(&self) -> Option<Arc<ZcashOrchardAddress>> {
         self.0.orchard().cloned().map(Into::into).map(Arc::new)
     }
 
+    /// Returns the Sapling receiver within this Unified Address, if any.
     pub fn sapling(&self) -> Option<Arc<ZcashPaymentAddress>> {
         self.0.sapling().cloned().map(Into::into).map(Arc::new)
     }
 
+    /// Returns the transparent receiver within this Unified Address, if any.
     pub fn transparent(&self) -> Option<Arc<ZcashTransparentAddress>> {
         self.0.transparent().cloned().map(Into::into).map(Arc::new)
+    }
+
+    pub fn decode(params: ZcashConsensusParameters, addr: &str) -> ZcashResult<Self> {
+        Ok(AddressCodec::decode(&params, addr).map(ZcashUnifiedAddress)?)
+    }
+
+    /// Returns the string encoding of this `UnifiedAddress` for the given network.
+    pub fn encode(&self, params: ZcashConsensusParameters) -> String {
+        self.0.encode(&params)
     }
 }

--- a/lib/uniffi-zcash/src/zcash_primitives/legacy/transparent_address.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/legacy/transparent_address.rs
@@ -3,7 +3,7 @@ use zcash_primitives::{consensus::Parameters, legacy::TransparentAddress};
 
 use crate::{utils, ZcashConsensusParameters, ZcashError, ZcashResult};
 
-/// A transparent address corresponding to either a public key or a script.
+/// A transparent address corresponding to either a public key or a `Script`.
 #[derive(Clone, Copy)]
 pub struct ZcashTransparentAddress(TransparentAddress);
 
@@ -20,17 +20,6 @@ impl From<ZcashTransparentAddress> for TransparentAddress {
 }
 
 impl ZcashTransparentAddress {
-    pub fn parse(params: ZcashConsensusParameters, input: &str) -> ZcashResult<Self> {
-        encoding::decode_transparent_address(
-            &params.b58_pubkey_address_prefix(),
-            &params.b58_script_address_prefix(),
-            input,
-        )
-        .map_err(|_| ZcashError::Unknown)?
-        .ok_or(ZcashError::Unknown)
-        .map(Into::into)
-    }
-
     /// Create new transparent address corresponding to public key
     pub fn public_key(input: Vec<u8>) -> ZcashResult<Self> {
         let buf = utils::cast_slice(&input)?;
@@ -43,6 +32,21 @@ impl ZcashTransparentAddress {
         Ok(TransparentAddress::Script(buf).into())
     }
 
+    /// Decodes a [`TransparentAddress`] from a Base58Check-encoded string.
+    pub fn decode(params: ZcashConsensusParameters, input: &str) -> ZcashResult<Self> {
+        encoding::decode_transparent_address(
+            &params.b58_pubkey_address_prefix(),
+            &params.b58_script_address_prefix(),
+            input,
+        )
+        .map_err(|_| ZcashError::Unknown)?
+        .ok_or(ZcashError::Unknown)
+        .map(Into::into)
+    }
+
+    /// Writes a [`TransparentAddress`] as a Base58Check-encoded string.
+    /// using the human-readable prefix values defined in the specified
+    /// network parameters.
     pub fn encode(&self, params: ZcashConsensusParameters) -> String {
         encoding::encode_transparent_address_p(&params, &self.0)
     }

--- a/lib/uniffi-zcash/tests/kotlin/test.kts
+++ b/lib/uniffi-zcash/tests/kotlin/test.kts
@@ -147,7 +147,7 @@ fun testUnifiedAddressParsing() {
 
     var thrown = false;
     try {
-        ZcashUnifiedAddress.parse(params, "")
+        ZcashUnifiedAddress.decode(params, "")
     } catch (e: ZcashException.Message) {
         thrown = true;
     }
@@ -168,10 +168,10 @@ fun testUnifiedAddressParsing() {
     val transparent = ZcashTransparentAddress.publicKey((1..20).map { it.toUByte() })
 
     val source = ZcashUnifiedAddress(orchard, sapling, transparent)
-    val address = source.toString(params)
-    val parsed = ZcashUnifiedAddress.parse(params, address)
+    val address = source.encode(params)
+    val parsed = ZcashUnifiedAddress.decode(params, address)
 
-    assert(address == parsed.toString(params))
+    assert(address == parsed.encode(params))
 }
 testUnifiedAddressParsing()
 
@@ -257,13 +257,13 @@ testUnifiedAddressCreationWithOrchard()
 fun testTransparentAddressParsing() {
     val net = ZcashConsensusParameters.TEST_NETWORK
     val input = "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma"
-    val parsed = ZcashTransparentAddress.parse(net, input)
+    val parsed = ZcashTransparentAddress.decode(net, input)
 
     assert(parsed.isPublicKey())
     assert(input == parsed.encode(net))
 
     val input2 = "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2"
-    val parsed2 = ZcashTransparentAddress.parse(net, input2)
+    val parsed2 = ZcashTransparentAddress.decode(net, input2)
 
     assert(parsed2.isScript())
     assert(input2 == parsed2.encode(net))

--- a/lib/uniffi-zcash/tests/python/test.py
+++ b/lib/uniffi-zcash/tests/python/test.py
@@ -126,7 +126,7 @@ class Test(unittest.TestCase):
         params = ZcashConsensusParameters.MAIN_NETWORK
 
         with self.assertRaises(ZcashError.Message) as e:
-            ZcashUnifiedAddress.parse(params, "")
+            ZcashUnifiedAddress.decode(params, "")
 
         sapling_diversifier = ZcashDiversifier([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
@@ -143,10 +143,10 @@ class Test(unittest.TestCase):
         transparent = ZcashTransparentAddress.public_key(range(1, 21))
 
         source = ZcashUnifiedAddress(orchard, sapling, transparent)
-        address = source.to_string(params)
-        parsed = ZcashUnifiedAddress.parse(params, address)
+        address = source.encode(params)
+        parsed = ZcashUnifiedAddress.decode(params, address)
 
-        self.assertEqual(address, parsed.to_string(params))
+        self.assertEqual(address, parsed.encode(params))
 
     def test_unified_address_creation_with_sapling(self):
         seed = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -222,13 +222,13 @@ class Test(unittest.TestCase):
     def test_transparent_address_parsing(self):
         net = ZcashConsensusParameters.TEST_NETWORK
         input = "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma"
-        parsed = ZcashTransparentAddress.parse(net, input)
+        parsed = ZcashTransparentAddress.decode(net, input)
 
         assert parsed.is_public_key()
         self.assertEqual(input, parsed.encode(net))
 
         input = "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2"
-        parsed = ZcashTransparentAddress.parse(net, input)
+        parsed = ZcashTransparentAddress.decode(net, input)
 
         assert parsed.is_script()
         self.assertEqual(input, parsed.encode(net))

--- a/lib/uniffi-zcash/tests/ruby/test.rb
+++ b/lib/uniffi-zcash/tests/ruby/test.rb
@@ -146,7 +146,7 @@ class TestApk < Test::Unit::TestCase
     params = Zcash::ZcashConsensusParameters::MAIN_NETWORK
 
     assert_raise Zcash::ZcashError::Message do
-      Zcash::ZcashUnifiedAddress::parse(params, "")
+      Zcash::ZcashUnifiedAddress::decode(params, "")
     end
 
     sapling_diversifier = Zcash::ZcashDiversifier.new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -164,10 +164,10 @@ class TestApk < Test::Unit::TestCase
     transparent = Zcash::ZcashTransparentAddress::public_key((1..20).to_a)
 
     source = Zcash::ZcashUnifiedAddress::new(orchard, sapling, transparent)
-    address = source.to_string(params)
-    parsed = Zcash::ZcashUnifiedAddress::parse(params, address)
+    address = source.encode(params)
+    parsed = Zcash::ZcashUnifiedAddress::decode(params, address)
 
-    assert_equal(address, parsed.to_string(params))
+    assert_equal(address, parsed.encode(params))
   end
 
   def test_unified_address_creation_with_sapling
@@ -253,13 +253,13 @@ class TestApk < Test::Unit::TestCase
   def test_transparent_address_parsing
     net = Zcash::ZcashConsensusParameters::TEST_NETWORK
     input = "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma"
-    parsed = Zcash::ZcashTransparentAddress::parse(net, input)
+    parsed = Zcash::ZcashTransparentAddress::decode(net, input)
 
     assert parsed.is_public_key
     assert_equal input, parsed.encode(net)
 
     input = "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2"
-    parsed = Zcash::ZcashTransparentAddress::parse(net, input)
+    parsed = Zcash::ZcashTransparentAddress::decode(net, input)
 
     assert parsed.is_script
     assert_equal input, parsed.encode(net)

--- a/lib/uniffi-zcash/tests/swift/test.swift
+++ b/lib/uniffi-zcash/tests/swift/test.swift
@@ -148,7 +148,7 @@ func testUnifiedAddressParsing() {
 
     var thrown = false;
     do {
-        let _ = try ZcashUnifiedAddress.parse(params: params, address: "")
+        let _ = try ZcashUnifiedAddress.decode(params: params, address: "")
     } catch ZcashError.Message {
         thrown = true
     } catch {
@@ -170,10 +170,10 @@ func testUnifiedAddressParsing() {
     let transparent = try! ZcashTransparentAddress.publicKey(data: Array(1...20))
 
     let source = try! ZcashUnifiedAddress(orchard: orchard, sapling: sapling, transparent: transparent)
-    let address = source.toString(params: params)
-    let parsed = try! ZcashUnifiedAddress.parse(params: params, address: address)
+    let address = source.encode(params: params)
+    let parsed = try! ZcashUnifiedAddress.decode(params: params, address: address)
 
-    assert(address == parsed.toString(params: params))
+    assert(address == parsed.encode(params: params))
 }
 testUnifiedAddressParsing()
 
@@ -259,13 +259,13 @@ testUnifiedAddressCreationWithOrchard()
 func testTransparentAddressParsing() {
     let net = ZcashConsensusParameters.testNetwork
     let input = "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma"
-    let parsed = try! ZcashTransparentAddress.parse(params: net, input: input)
+    let parsed = try! ZcashTransparentAddress.decode(params: net, input: input)
 
     assert(parsed.isPublicKey())
     assert(input == parsed.encode(params: net))
 
     let input2 = "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2"
-    let parsed2 = try! ZcashTransparentAddress.parse(params: net, input: input2)
+    let parsed2 = try! ZcashTransparentAddress.decode(params: net, input: input2)
 
     assert(parsed2.isScript())
     assert(input2 == parsed2.encode(params: net))


### PR DESCRIPTION
Also: add `decode` to `RecipientAddress`, fix names to match `librustzcash`, update `STATUS.md`.