### PR TITLE
initial setup for transaction implementation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -479,6 +479,195 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 | S256            |              | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | S512            |              | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 
+### ZcashTransactionBuilder
+
+* Original type: [zcash_primitives::transaction::builder::Builder](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/builder/struct.Builder.html)
+
+| Members                                           | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashTransactionBuilder::test_only_new_with_rng() | ⚪     |     |      |       |      |
+| ZcashTransactionBuilder::mock_build()             | ⚪     |     |      |       |      |
+| ZcashTransactionBuilder::params()                 | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::target_height()          | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::transparent_inputs()     | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::transparent_outputs()    | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::sapling_inputs()         | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::sapling_outputs()        | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::new()                    | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::new_with_rng()           | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::add_sapling_spend()      | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::add_sapling_output()     | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::add_transparent_input()  | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::add_transparent_output() | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::with_progress_notifier() | 🔵     |     |      |       |      |
+| ZcashTransactionBuilder::build()                  | 🔴     |     |      |       |      |
+| ZcashTransactionBuilder::build_zfuture()          | 🔵     |     |      |       |      |
+
+
+### ZcashParametersMainNetwork
+* Original type: [zcash_primitives::consensus::MainNetwork](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/consensus/struct.MainNetwork.html)
+* Marker struct, no need to implement methods.
+
+| Members | Score | UDL | Code | Tests | Docs |
+| ------- | ----- | --- | ---- | ----- | ---- |
+
+### ZcashParametersTestNetwork
+* Original type: [zcash_primitives::consensus::TestNetwork](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/consensus/struct.TestNetwork.html)
+* Marker struct, no need to implement methods.
+
+| Members | Score | UDL | Code | Tests | Docs |
+| ------- | ----- | --- | ---- | ----- | ---- |
+
+### ZcashBlockHeight
+
+* Original type: [zcash_primitives::consensus::BlockHeight](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/consensus/struct.BlockHeight.html)
+
+| Members                      | Score | UDL | Code | Tests | Docs |
+| ---------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashBlockHeight::from_u32() | 🔴     |     |      |       |      |
+
+
+### ZcashExternalIvk
+
+* Original type: [zcash_primitives::legacy::keys::ExternalIvk](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/legacy/keys/struct.ExternalIvk.html)
+
+| Members                            | Score | UDL | Code | Tests | Docs |
+| ---------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashExternalIvk::derive_address() | 🔴     |     |      |       |      |
+
+### ZcashTransparentTxOut
+
+* Original type: [zcash_primitives::transaction::components::transparent::TxOut](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/components/transparent/struct.TxOut.html)
+
+| Members                                    | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------ | ----- | --- | ---- | ----- | ---- |
+| ZcashTransparentTxOut::read()              | 🔵     |     |      |       |      |
+| ZcashTransparentTxOut::write()             | 🔵     |     |      |       |      |
+| ZcashTransparentTxOut::recipient_address() | 🔵     |     |      |       |      |
+
+### ZcashAmount
+
+* Original type: [zcash_primitives::transaction::components::amount::Amount](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/components/amount/struct.Amount.html)
+
+| Members                                      | Score | UDL | Code | Tests | Docs |
+| -------------------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashAmount::zero()                          | 🔴     |     |      |       |      |
+| ZcashAmount::from_i64()                      | 🔴     |     |      |       |      |
+| ZcashAmount::from_nonnegative_i64()          | 🔴     |     |      |       |      |
+| ZcashAmount::from_u64()                      | 🔴     |     |      |       |      |
+| ZcashAmount::from_i64_le_bytes()             | 🔵     |     |      |       |      |
+| ZcashAmount::from_i64_le_bytes()             | 🔵     |     |      |       |      |
+| ZcashAmount::from_nonnegative_i64_le_bytes() | 🔵     |     |      |       |      |
+| ZcashAmount::from_i64_le_bytes()             | 🔵     |     |      |       |      |
+| ZcashAmount::to_i64_le_bytes()               | 🔵     |     |      |       |      |
+| ZcashAmount::is_positive()                   | 🔵     |     |      |       |      |
+| ZcashAmount::is_negative()                   | 🔵     |     |      |       |      |
+| ZcashAmount::sum()                           | 🔵     |     |      |       |      |
+
+### ZcashTransparentOutPoint
+
+* Original type: [zcash_primitives::transaction::components::transparent::OutPoint](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/components/transparent/struct.OutPoint.html)
+
+| Members                           | Score | UDL | Code | Tests | Docs |
+| --------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashTransparentOutPoint::new()   | 🔴     |     |      |       |      |
+| ZcashTransparentOutPoint::read()  | 🔵     |     |      |       |      |
+| ZcashTransparentOutPoint::write() | 🔵     |     |      |       |      |
+| ZcashTransparentOutPoint::n()     | 🔵     |     |      |       |      |
+| ZcashTransparentOutPoint::hash()  | 🔵     |     |      |       |      |
+
+### ZcashLocalTxProver
+
+* Original type: [zcash_proofs::prover::LocalTxProver](https://docs.rs/zcash_proofs/latest/zcash_proofs/prover/struct.LocalTxProver.html)
+
+| Members                                     | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashLocalTxProver::new()                   | 🔴     |     |      |       |      |
+| ZcashLocalTxProver::bundled()               | 🔴     |     |      |       |      |
+| ZcashLocalTxProver::from_bytes()            | 🔴     |     |      |       |      |
+| ZcashLocalTxProver::with_default_location() | 🔴     |     |      |       |      |
+| ZcashLocalTxProver::hash()                  | 🔴     |     |      |       |      |
+
+### ZcashFixedFeeRule
+
+* Original type: [zcash_primitives::transaction::fees::fixed::FeeRule](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/fees/fixed/struct.FeeRule.html)
+
+| Members                      | Score | UDL | Code | Tests | Docs |
+| ---------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashFeeRule::non_standard() | 🔴     |     |      |       |      |
+| ZcashFeeRule::standard()     | 🔴     |     |      |       |      |
+| ZcashFeeRule::fixed_fee()    | 🔴     |     |      |       |      |
+
+### ZcashZip317FeeRule
+
+* Original type: [zcash_primitives::transaction::fees::zip317::FeeRule](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/fees/zip317/struct.FeeRule.html)
+
+| Members                                    | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------ | ----- | --- | ---- | ----- | ---- |
+| ZcashFeeRule::non_standard()               | 🔴     |     |      |       |      |
+| ZcashFeeRule::standard()                   | 🔴     |     |      |       |      |
+| ZcashFeeRule::marginal_fee()               | 🔴     |     |      |       |      |
+| ZcashFeeRule::p2pkh_standard_input_size()  | 🔵     |     |      |       |      |
+| ZcashFeeRule::p2pkh_standard_output_size() | 🔵     |     |      |       |      |
+
+### ZcashSaplingRseed
+
+* Original type: [zcash_primitives::sapling::note::Rseed](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/sapling/note/enum.Rseed.html)
+* Its an Enum type. No methods to implement.
+
+| Members | Score | UDL | Code | Tests | Docs |
+| ------- | ----- | --- | ---- | ----- | ---- |
+
+### ZcashCommitmentTree
+
+* Original type: [zcash_primitives::merkle_tree::CommitmentTree](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/merkle_tree/struct.CommitmentTree.html)
+
+| Members                              | Score | UDL | Code | Tests | Docs |
+| ------------------------------------ | ----- | --- | ---- | ----- | ---- |
+| ZcashCommitmentTree::empty()         | 🔴     |     |      |       |      |
+| ZcashCommitmentTree::from_frontier() | 🔵     |     |      |       |      |
+| ZcashCommitmentTree::to_frontier()   | 🔵     |     |      |       |      |
+| ZcashCommitmentTree::size()          | 🔵     |     |      |       |      |
+| ZcashCommitmentTree::read()          | 🔵     |     |      |       |      |
+| ZcashCommitmentTree::write()         | 🔵     |     |      |       |      |
+| ZcashCommitmentTree::append()        | 🔴     |     |      |       |      |
+| ZcashCommitmentTree::root()          | 🔵     |     |      |       |      |
+
+### ZcashSaplingTreeNode
+
+* Original type: [zcash_primitives::sapling::Node](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/sapling/struct.Node.html)
+
+| Members                             | Score | UDL | Code | Tests | Docs |
+| ----------------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingTreeNode::from_cmu()    | 🔴     |     |      |       |      |
+| ZcashSaplingTreeNode::from_scalar() | 🔵     |     |      |       |      |
+
+### ZcashIncrementalWitness
+
+* Original type: [zcash_primitives::merkle_tree::IncrementalWitness](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/merkle_tree/struct.IncrementalWitness.html)
+
+| Members                              | Score | UDL | Code | Tests | Docs |
+| ------------------------------------ | ----- | --- | ---- | ----- | ---- |
+| ZcashIncrementalWitness::from_tree() | 🔴     |     |      |       |      |
+| ZcashIncrementalWitness::read()      | 🔵     |     |      |       |      |
+| ZcashIncrementalWitness::write()     | 🔵     |     |      |       |      |
+| ZcashIncrementalWitness::position()  | 🔵     |     |      |       |      |
+| ZcashIncrementalWitness::filler()    | 🔵     |     |      |       |      |
+| ZcashIncrementalWitness::append()    | 🔴     |     |      |       |      |
+| ZcashIncrementalWitness::root()      | 🔵     |     |      |       |      |
+| ZcashIncrementalWitness::path()      | 🔵     |     |      |       |      |
+
+### ZcashMemoBytes
+
+* Original type: [zcash_primitives::memo::MemoBytes](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/memo/struct.MemoBytes.html)
+
+| Members                      | Score | UDL | Code | Tests | Docs |
+| ---------------------------- | ----- | --- | ---- | ----- | ---- |
+| ZcashMemoBytes::empty()      | 🔴     |     |      |       |      |
+| ZcashMemoBytes::from_bytes() | 🔴     |     |      |       |      |
+| ZcashMemoBytes::as_array()   | 🔵     |     |      |       |      |
+| ZcashMemoBytes::as_slice()   | 🔵     |     |      |       |      |
+
 ### ZcashDiversifierIndexAndPaymentAddress
 
 A pair of [ZcashDiversifierIndex](#zcashdiversifierindex) and [ZcashPaymentAddress](#zcashpaymentaddress-sapling).

--- a/lib/uniffi-zcash/Cargo.toml
+++ b/lib/uniffi-zcash/Cargo.toml
@@ -19,6 +19,7 @@ hdwallet = "0.3.1"
 zcash_address = "0.2.0"
 zcash_primitives = { version = "0.10.0", features = ["transparent-inputs"] }
 zcash_client_backend = { version = "0.7.0", features = ["transparent-inputs", "unstable"] }
+zcash_proofs = {version = "0.10.0", features= ["bundled-prover"]}
 orchard = {version= "0.3.0"}
 secp256k1 = {version = "0.21.3"}
 jubjub = {version = "0.9.0"}

--- a/lib/uniffi-zcash/src/bin/transaction.rs
+++ b/lib/uniffi-zcash/src/bin/transaction.rs
@@ -1,0 +1,118 @@
+use zcash_client_backend::keys::UnifiedSpendingKey;
+use zcash_primitives::{
+    consensus::{BlockHeight, MainNetwork},
+    legacy::keys::IncomingViewingKey,
+    memo::MemoBytes,
+    merkle_tree::{CommitmentTree, IncrementalWitness},
+    sapling::Node,
+    transaction::{
+        builder::Builder,
+        components::{Amount, OutPoint, TxOut},
+        fees::fixed,
+    },
+    zip32::Scope,
+};
+use zcash_proofs::prover::LocalTxProver;
+
+const BLOCK_HEIGHT: u32 = 2030820;
+
+fn main() {
+    let mut seed = vec![0u8; 32];
+    seed[0] = 1u8;
+    let key = UnifiedSpendingKey::from_seed(&MainNetwork, &seed, 0.into()).unwrap();
+
+    transparent_transaction_general_builder_example(&key);
+    println!();
+    sapling_transaction_general_builder_example(&key);
+}
+
+pub fn transparent_transaction_general_builder_example(key: &UnifiedSpendingKey) {
+    let mut builder = Builder::new(MainNetwork, BlockHeight::from_u32(BLOCK_HEIGHT));
+
+    // Transparent data
+    let address = key
+        .transparent()
+        .to_account_pubkey()
+        .derive_external_ivk()
+        .unwrap()
+        .derive_address(0)
+        .unwrap();
+    let prev_coin = TxOut {
+        value: Amount::from_u64(200).unwrap(),
+        script_pubkey: address.script(),
+    };
+    let secret_key = key.transparent().derive_external_secret_key(0).unwrap();
+    builder
+        .add_transparent_input(secret_key, OutPoint::new([0u8; 32], 1), prev_coin)
+        .unwrap();
+
+    builder
+        .add_transparent_output(&address, Amount::from_u64(200).unwrap())
+        .unwrap();
+
+    let prover = LocalTxProver::bundled(); // This can increase binary size byb 50MB.
+    let fee_rule = fixed::FeeRule::non_standard(Amount::zero());
+
+    let (transaction, _) = builder.build(&prover, &fee_rule).unwrap();
+    let mut data = Vec::new();
+    transaction.write(&mut data).unwrap();
+    println!("Transparent transaction data (from general builder)");
+    println!("___________________________________________________");
+    println!(
+        "[{}]",
+        data.iter()
+            .map(|byte| byte.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
+}
+
+pub fn sapling_transaction_general_builder_example(key: &UnifiedSpendingKey) {
+    let mut builder = Builder::new(MainNetwork, BlockHeight::from_u32(BLOCK_HEIGHT));
+
+    let extsk = key.sapling().clone();
+    let (_, payment_address) = extsk.default_address();
+    let rseed = zcash_primitives::sapling::Rseed::AfterZip212([0u8; 32]);
+    let note = payment_address.create_note(200, rseed);
+    let mut tree = CommitmentTree::empty();
+    tree.append(Node::from_cmu(&note.cmu())).unwrap();
+    let witness = IncrementalWitness::from_tree(&tree);
+
+    builder
+        .add_sapling_spend(
+            extsk,
+            *payment_address.diversifier(),
+            note,
+            witness.path().unwrap(),
+        )
+        .unwrap();
+
+    builder
+        .add_sapling_output(
+            Some(
+                key.sapling()
+                    .to_diversifiable_full_viewing_key()
+                    .to_ovk(Scope::Internal),
+            ),
+            payment_address,
+            Amount::from_u64(200).unwrap(),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+
+    let prover = LocalTxProver::bundled();
+    let fee_rule = fixed::FeeRule::non_standard(Amount::zero());
+    let (transaction, _) = builder.build(&prover, &fee_rule).unwrap();
+
+    let mut data = Vec::new();
+    transaction.write(&mut data).unwrap();
+    println!("Sapling transaction data (from general builder)");
+    println!("_______________________________________________");
+    println!(
+        "[{}]",
+        data.iter()
+            .map(|byte| byte.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
+}


### PR DESCRIPTION
* Adds examples for `Transparent` and `Sapling` transaction creation.
* Updates `STATUS.md` with the needed entities for creating transactions.
