### PR TITLE
Add basic FFI API surface to properly inspect a transaction

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1208,7 +1208,7 @@ A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orc
 
 A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 
-### ZcashOrchardBundleDecryptOutputForKeys
+### ZcashOrchardBundleDecryptOutputForOutgoingKeys
 
 A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1206,11 +1206,11 @@ A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orc
 
 ### ZcashOrchardBundleDecryptOutput
 
-A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) `decrypt_output_with_key()` method.
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 
 ### ZcashOrchardBundleDecryptOutputForKeys
 
-A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) `decrypt_output_with_keys` method.
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 
 ## Functions
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1033,7 +1033,7 @@ a tuple.
 | ZcashOrchardBundle::flags()                    | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::verify_proof()             | 🔴    |  ✅ |  ✅  |      |  ✅  |
-| ZcashOrchardBundle::recover_output_with_ovk()  | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::recover_output_with_ovk()  | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::recover_outputs_with_ovks()| 🔴    |     |      |      |      |
 | ZcashOrchardBundle::commitment()               |       |     |      |      |      |
 | ZcashOrchardBundle::map_authorization()        |       |     |      |      |      |

--- a/STATUS.md
+++ b/STATUS.md
@@ -920,6 +920,101 @@ a tuple.
 | ZcashTxId::vin()                    | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTxId::vout()                   | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
+### ZcashSaplingBundle
+
+* Original type: [zcash_primitives::transaction::components::sapling::Bundle](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/components/sapling/struct.Bundle.html)
+* Implemented the authorized implementation.
+
+
+| Members                                | Score | UDL | Code | Tests | Docs |
+| ---------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingBundle::shielded_spends()  | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingBundle::shielded_outputs() | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingBundle::value_balance()    | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingBundle::value_balance()    | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+
+### ZcashSaplingSpendDescription
+
+* Original type: [zcash_primitives::transaction::components::sapling::SpendDescription](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/components/sapling/struct.SpendDescription.html)
+* Implemented the authorized implementation.
+
+
+| Members                                         | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingSpendDescription::cv()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::anchor()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::nullifier()       | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::rk()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::zkproof()         |       |     |       |      |      |
+| ZcashSaplingSpendDescription::spend_auth_sig()  |       |     |       |      |      |
+
+### ZcashSaplingOutputDescription
+
+* Original type: [zcash_primitives::transaction::components::sapling::OutputDescription](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/components/sapling/struct.OutputDescription.html)
+* Implemented the authorized implementation.
+
+
+| Members                                         | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingSpendDescription::cv()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::cmu()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::ephemeral_key()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::enc_ciphertext()  | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingSpendDescription::out_ciphertext()  |       |     |       |      |      |
+| ZcashSaplingSpendDescription::zkproof()         |       |     |       |      |      |
+| ZcashSaplingSpendDescription::read()            |       |     |       |      |      |
+| ZcashSaplingSpendDescription::write_v4()         |       |     |       |      |      |
+| ZcashSaplingSpendDescription::write_v5_without_proof()  |       |     |       |      |      |
+
+### ZcashSaplingValueCommitment
+
+* Original type: [zcash_primitives::sapling::value::ValueCommitment](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/sapling/value/struct.ValueCommitment.html)
+
+
+| Members                                         | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingValueCommitment::derive()           |       |     |       |      |      |
+| ZcashSaplingValueCommitment::as_inner()         |       |     |       |      |      |
+| ZcashSaplingValueCommitment::from_bytes_not_small_order() |       |     |       |      |      |
+| ZcashSaplingValueCommitment::to_bytes()         | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+### ZcashSaplingNullifier
+
+* Original type: [zcash_primitives::sapling::Nullifier](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/sapling/struct.Nullifier.html)
+
+| Members                                   | Score | UDL | Code | Tests | Docs |
+| ------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingNullifier::from_slice()       |       |     |      |      |      |
+| ZcashSaplingNullifier::to_bytes()         | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+### ZcashSaplingPublicKey
+
+* Original type: [zcash_primitives::sapling::redjubjub::PublicKey](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/sapling/redjubjub/struct.PublicKey.html)
+
+| Members                                      | Score | UDL | Code | Tests | Docs |
+| ---------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingPublicKey::from_private()        |       |     |      |      |      |
+| ZcashSaplingPublicKey::randomize()           |       |     |      |      |      |
+| ZcashSaplingPublicKey::read()                |       |     |      |      |      |
+| ZcashSaplingPublicKey::write()               |       |     |      |      |      |
+| ZcashSaplingPublicKey::verify()              |       |     |      |      |      |
+| ZcashSaplingPublicKey::verify_with_zip216()  |       |     |      |      |       |    
+| ZcashSaplingPublicKey::to_bytes()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
+
+* The `write()` method was implemented as `to_bytes()`
+
+### ZcashSaplingValueCommitment
+
+* Original type: [zcash_primitives::sapling::value::ValueCommitment](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/sapling/value/struct.ValueCommitment.html)
+
+| Members                                      | Score | UDL | Code | Tests | Docs |
+| ---------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingPublicKey::derive()              |       |     |      |      |      |
+| ZcashSaplingPublicKey::as_inner()            |       |     |      |      |      |
+| ZcashSaplingPublicKey::from_bytes_not_small_order() |       |     |      |      |      |
+| ZcashSaplingPublicKey::to_bytes()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
+  
 ## Enums
 
 ### ZcashScope

--- a/STATUS.md
+++ b/STATUS.md
@@ -568,6 +568,7 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 | ZcashTransaction::consensus_branch_id()| 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::lock_time()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::expiry_height()      | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::fee_paid()           | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 * `write` method was implemented as `to_bytes()`.
 * `read` method was implemented as `from_bytes()`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1032,7 +1032,7 @@ a tuple.
 | ZcashOrchardBundle::decrypt_outputs_with_keys()| 🔴    |     |      |      |      |
 | ZcashOrchardBundle::flags()                    | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
-| ZcashOrchardBundle::verify_proof()             | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::verify_proof()             | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::recover_output_with_ovk()  | 🔴    |     |      |      |      |
 | ZcashOrchardBundle::recover_outputs_with_ovks()| 🔴    |     |      |      |      |
 | ZcashOrchardBundle::commitment()               |       |     |      |      |      |
@@ -1076,6 +1076,22 @@ a tuple.
 | ZcashOrchardValueCommitment::derive()    |       |     |      |      |      |
 | ZcashOrchardValueCommitment::from_bytes()|       |     |      |      |      |
 | ZcashOrchardValueCommitment::to_bytes()  | 🔴    |  ✅ |  ✅  |      |  ✅  |
+
+### ZcashVerifyingKey
+
+* Original type: [orchard::circuit::VerifyingKey](https://docs.rs/orchard/0.3.0/orchard/circuit/struct.VerifyingKey.html)
+
+| Members                                  | Score | UDL | Code | Tests | Docs |
+| -----------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashVerifyingKey::build()               | 🔴    |  ✅ |  ✅  |      |  ✅  |
+
+### ZcashProvingKey
+
+* Original type: [orchard::circuit::ProvingKey](https://docs.rs/orchard/0.3.0/orchard/circuit/struct.ProvingKey.html)
+
+| Members                                  | Score | UDL | Code | Tests | Docs |
+| -----------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashProvingKey::build()               | 🔴    |  ✅ |  ✅  |      |  ✅  |
 
 ## Enums
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1028,7 +1028,7 @@ a tuple.
 | ZcashOrchardBundle::authorization()            |       |     |      |      |      |
 | ZcashOrchardBundle::authorizing_commitment()   |       |     |      |      |      |
 | ZcashOrchardBundle::binding_validating_key()   |       |     |      |      |      |
-| ZcashOrchardBundle::decrypt_output_with_key()  | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::decrypt_output_with_key()  | 🔴    |  ✅ |  ✅  |      | ✅   |
 | ZcashOrchardBundle::decrypt_outputs_with_keys()| 🔴    |     |      |      |      |
 | ZcashOrchardBundle::flags()                    | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
@@ -1203,6 +1203,10 @@ A pair of [ZcashTransaction](#zcashtransaction) and [ZcashSaplingMetadata](#zcas
 ### ZcashTransmittedNoteCiphertext
 
 A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orchard/0.3.0/orchard/note/struct.TransmittedNoteCiphertext.html)
+
+### ZcashOrchardBundleDecryptOutput
+
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 
 ## Functions
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1034,7 +1034,7 @@ a tuple.
 | ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::verify_proof()             | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::recover_output_with_ovk()  | 🔴    |  ✅ |  ✅  |      |  ✅  |
-| ZcashOrchardBundle::recover_outputs_with_ovks()| 🔴    |     |      |      |      |
+| ZcashOrchardBundle::recover_outputs_with_ovks()| 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::commitment()               |       |     |      |      |      |
 | ZcashOrchardBundle::map_authorization()        |       |     |      |      |      |
 
@@ -1205,6 +1205,10 @@ A pair of [ZcashTransaction](#zcashtransaction) and [ZcashSaplingMetadata](#zcas
 A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orchard/0.3.0/orchard/note/struct.TransmittedNoteCiphertext.html)
 
 ### ZcashOrchardBundleDecryptOutput
+
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
+
+### ZcashOrchardBundleDecryptOutputForIncomingKeys
 
 A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1200,7 +1200,7 @@ A pair of [ZcashDiversifierIndex](#zcashdiversifierindex) and [ZcashPaymentAddre
 
 A pair of [ZcashTransaction](#zcashtransaction) and [ZcashSaplingMetadata](#zcashsaplingmetadata)
 
-### TransmittedNoteCiphertext
+### ZcashTransmittedNoteCiphertext
 
 A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orchard/0.3.0/orchard/note/struct.TransmittedNoteCiphertext.html)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -937,6 +937,38 @@ See [ZcashTransactionBuilder](#zcashtransactionbuilder).
 | Nu5        |  🔴   | :white_check_mark: | :white_check_mark: |       | :white_check_mark: |
 | ZFuture    |  🔵   |                       |                       |                               |
 
+
+### ZcashTxVersionSelection
+
+* Original type: [zcash_primitives::transaction::TxVersion](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/enum.TxVersion.html)
+
+| Members                     | Score | UDL | Code | Tests | Docs |
+| ----------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTxVersion::Sprout      | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::Overwinter  | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::Sapling     | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::Zip225      | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::ZFuture     | 🔵    |     |      |       |      |
+
+The methods in this enum and the enum itself are contained in the following type:
+
+#### ZcashTxVersion
+
+| Members                               | Score | UDL | Code | Tests | Docs |
+| --------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTxVersion::selection()           | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::from_bytes()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::header()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::version_group_id()    | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::to_bytes()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::has_sprout()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::has_overwinter()      | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::has_sapling()         | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::has_orchard()         | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxVersion::suggested_for_branch()| 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+The `selection()` method is a pure invention one, that helps on retrieving the enum variant `ZcashTxVersionSelection`.
+
 ## Records
 
 ### ZcashDiversifierIndexAndScope

--- a/STATUS.md
+++ b/STATUS.md
@@ -822,10 +822,10 @@ a tuple.
 
 * Original type: [orchard::note::ExtractedNoteCommitment](https://docs.rs/orchard/0.3.0/orchard/note/struct.ExtractedNoteCommitment.html)
 
-| Members                             | Score | UDL | Code | Tests | Docs |
-| ------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashOrchardNoteValue::from_bytes() | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashOrchardNoteValue::to_bytes()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| Members                                    | Score | UDL | Code | Tests | Docs |
+| -------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashExtractedNoteCommitment::from_bytes() | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashExtractedNoteCommitment::to_bytes()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 ### ZcashAnchor
 
@@ -833,8 +833,8 @@ a tuple.
 
 | Members                             | Score | UDL | Code | Tests | Docs |
 | ------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashOrchardNoteValue::from_bytes() | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashOrchardNoteValue::to_bytes()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashAnchor::from_bytes()           | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashAnchor::to_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 ### ZcashOrchardNote
 
@@ -904,8 +904,8 @@ a tuple.
 
 | Members                             | Score | UDL | Code | Tests | Docs |
 | ------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashTxId::to_bytes()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTxId::from_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxIn::to_bytes()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxIn::from_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 
 ### ZcashTransparentBundle
@@ -914,13 +914,13 @@ a tuple.
 * Implemented the authorized implementation.
 * `vin()` and `vout()` methods are pure invention methods, to access the pub struct fields.
 
-| Members                             | Score | UDL | Code | Tests | Docs |
-| ------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashTxId::is_coinbase()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTxId::map_authorization()      | 🔵    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTxId::value_balance()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTxId::vin()                    | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTxId::vout()                   | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| Members                                 | Score | UDL | Code | Tests | Docs |
+| ----------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTransparentBundle::is_coinbase()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransparentBundle::map_authorization()      | 🔵    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransparentBundle::value_balance()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransparentBundle::vin()                    | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashZcashTransparentBundleTxId::vout()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 ### ZcashSaplingBundle
 
@@ -959,15 +959,15 @@ a tuple.
 
 | Members                                         | Score | UDL | Code | Tests | Docs |
 | ------------------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashSaplingSpendDescription::cv()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashSaplingSpendDescription::cmu()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashSaplingSpendDescription::ephemeral_key()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashSaplingSpendDescription::enc_ciphertext()  | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashSaplingSpendDescription::out_ciphertext()  |       |     |       |      |      |
-| ZcashSaplingSpendDescription::zkproof()         |       |     |       |      |      |
-| ZcashSaplingSpendDescription::read()            |       |     |       |      |      |
-| ZcashSaplingSpendDescription::write_v4()         |       |     |       |      |      |
-| ZcashSaplingSpendDescription::write_v5_without_proof()  |       |     |       |      |      |
+| ZcashSaplingOutputDescription::cv()              | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingOutputDescription::cmu()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingOutputDescription::ephemeral_key()   | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingOutputDescription::enc_ciphertext()  | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashSaplingOutputDescription::out_ciphertext()  |       |     |       |      |      |
+| ZcashSaplingOutputDescription::zkproof()         |       |     |       |      |      |
+| ZcashSaplingOutputDescription::read()            |       |     |       |      |      |
+| ZcashSaplingOutputDescription::write_v4()         |       |     |       |      |      |
+| ZcashSaplingOutputDescription::write_v5_without_proof()  |       |     |       |      |      |
 
 ### ZcashSaplingValueCommitment
 
@@ -1011,11 +1011,11 @@ a tuple.
 * Original type: [zcash_primitives::sapling::value::ValueCommitment](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/sapling/value/struct.ValueCommitment.html)
 
 | Members                                      | Score | UDL | Code | Tests | Docs |
-| ---------------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashSaplingPublicKey::derive()              |       |     |      |      |      |
-| ZcashSaplingPublicKey::as_inner()            |       |     |      |      |      |
-| ZcashSaplingPublicKey::from_bytes_not_small_order() |       |     |      |      |      |
-| ZcashSaplingPublicKey::to_bytes()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ---------------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashSaplingValueCommitment::derive()              |       |     |      |      |      |
+| ZcashSaplingValueCommitment::as_inner()            |       |     |      |      |      |
+| ZcashSaplingValueCommitment::from_bytes_not_small_order() |       |     |      |      |      |
+| ZcashSaplingValueCommitment::to_bytes()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
   
 ### ZcashOrchardBundle (Authorized)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -882,6 +882,15 @@ a tuple.
 | ZcashOrchardMerkleHash::to_bytes()  | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashOrchardMerkleHash::from_bytes()| 🔴    |  ✅ |  ✅  |  ✅   |  ✅  |
 
+### ZcashTxId
+
+* Original type: [zcash_primitives::transaction::TxId](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/struct.TxId.html)
+
+| Members                             | Score | UDL | Code | Tests | Docs |
+| ------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTxId::to_bytes()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::from_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
 ## Enums
 
 ### ZcashScope

--- a/STATUS.md
+++ b/STATUS.md
@@ -569,6 +569,7 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 | ZcashTransaction::lock_time()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::expiry_height()      | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::fee_paid()           | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::transparent_bundle() | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 * `write` method was implemented as `to_bytes()`.
 * `read` method was implemented as `from_bytes()`.
@@ -891,6 +892,32 @@ a tuple.
 | ------------------------------------| ----- | --- | ---- | ----- | ---- |
 | ZcashTxId::to_bytes()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTxId::from_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+
+### ZcashTxIn
+
+* Original type: [zcash_primitives::transaction::components::transparent::TxIn](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/components/transparent/struct.TxIn.html)
+* Implemented the authorized implementation.
+
+| Members                             | Score | UDL | Code | Tests | Docs |
+| ------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTxId::to_bytes()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::from_bytes()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
+
+
+### ZcashTransparentBundle
+
+* Original type: [zcash_primitives::transaction::components::transparent::Bundle](https://docs.rs/zcash_primitives/0.10.0/zcash_primitives/transaction/components/transparent/struct.Bundle.html)
+* Implemented the authorized implementation.
+* `vin()` and `vout()` methods are pure invention methods, to access the pub struct fields.
+
+| Members                             | Score | UDL | Code | Tests | Docs |
+| ------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTxId::is_coinbase()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::map_authorization()      | 🔵    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::value_balance()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::vin()                    | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTxId::vout()                   | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 ## Enums
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -573,6 +573,7 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 
 * `write` method was implemented as `to_bytes()`.
 * `read` method was implemented as `from_bytes()`.
+* `fee_paid` method is commented in code. It needs a closure as parameter.
 
 ### ZcashSaplingMetadata
 | ZcashSaplingMetadata::spend_index()  | 🔴    | ✅  |  ✅  |       | ✅   |

--- a/STATUS.md
+++ b/STATUS.md
@@ -559,12 +559,15 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 * Original type: [zcash_primitives::transaction::Transaction](https://docs.rs/zcash_primitives/0.10.2/zcash_primitives/transaction/struct.Transaction.html)
 
 
-| Members                              | Score | UDL | Code | Tests | Docs |
-| -------------------------------------| ----- | --- | ---- | ----- | ---- |
-| ZcashTransaction::into_data()        | 🔴    |     |      |       |      |
-| ZcashTransaction::txid()             | 🔴    |     |      |       |      |
-| ZcashTransaction::read()             | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTransaction::write()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| Members                                | Score | UDL | Code | Tests | Docs |
+| ---------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashTransaction::into_data()          | 🔴    |     |      |       |      |
+| ZcashTransaction::txid()               | 🔴    |     |      |       |      |
+| ZcashTransaction::read()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::version()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::consensus_branch_id()| 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::lock_time()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::expiry_height()      | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 * `write` method was implemented as `to_bytes()`.
 * `read` method was implemented as `from_bytes()`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -562,14 +562,16 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 | Members                                | Score | UDL | Code | Tests | Docs |
 | ---------------------------------------| ----- | --- | ---- | ----- | ---- |
 | ZcashTransaction::into_data()          | 🔴    |     |      |       |      |
-| ZcashTransaction::txid()               | 🔴    |     |      |       |      |
+| ZcashTransaction::txid()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::read()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::version()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::consensus_branch_id()| 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::lock_time()          | 🔴    |  ✅ |  ✅  |       |  ✅  |
 | ZcashTransaction::expiry_height()      | 🔴    |  ✅ |  ✅  |       |  ✅  |
-| ZcashTransaction::fee_paid()           | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::fee_paid()           | 🔴    |     |      |       |       |
 | ZcashTransaction::transparent_bundle() | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::sapling_bundle()     | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashTransaction::orchard_bundle()     | 🔴    |  ✅ |  ✅  |       |  ✅  |
 
 * `write` method was implemented as `to_bytes()`.
 * `read` method was implemented as `from_bytes()`.
@@ -1015,6 +1017,66 @@ a tuple.
 | ZcashSaplingPublicKey::from_bytes_not_small_order() |       |     |      |      |      |
 | ZcashSaplingPublicKey::to_bytes()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
   
+### ZcashOrchardBundle (Authorized)
+
+* Original type: [orchard::bundle::Bundle](https://docs.rs/orchard/0.3.0/orchard/bundle/struct.Bundle.html)
+
+| Members                                        | Score | UDL | Code | Tests | Docs |
+| -----------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashOrchardBundle::actions()                  | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardBundle::anchor()                   | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardBundle::authorization()            |       |     |      |      |      |
+| ZcashOrchardBundle::authorizing_commitment()   |       |     |      |      |      |
+| ZcashOrchardBundle::binding_validating_key()   |       |     |      |      |      |
+| ZcashOrchardBundle::decrypt_output_with_key()  | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::decrypt_outputs_with_keys()| 🔴    |     |      |      |      |
+| ZcashOrchardBundle::flags()                    | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardBundle::verify_proof()             | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::recover_output_with_ovk()  | 🔴    |     |      |      |      |
+| ZcashOrchardBundle::recover_outputs_with_ovks()| 🔴    |     |      |      |      |
+| ZcashOrchardBundle::commitment()               |       |     |      |      |      |
+| ZcashOrchardBundle::map_authorization()        |       |     |      |      |      |
+
+### ZcashOrchardFlags
+
+* Original type: [orchard::bundle::Flags](https://docs.rs/orchard/0.3.0/orchard/bundle/struct.Flags.html)
+
+| Members                                    | Score | UDL | Code | Tests | Docs |
+| -------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashOrchardFlags::from_parts()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardFlags::spends_enabled()        | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardFlags::outputs_enabled()       | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardFlags::to_byte()               | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardFlags::from_byte()             | 🔴    |  ✅ |  ✅  |      |  ✅  |
+
+### ZcashOrchardAction
+
+* Original type: [orchard::Action](https://docs.rs/orchard/0.3.0/orchard/struct.Action.html)
+
+| Members                                    | Score | UDL | Code | Tests | Docs |
+| -------------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashOrchardAction::from_parts()           |       |     |      |       |      |
+| ZcashOrchardAction::nullifier()            | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashOrchardAction::rk()                   |       |     |      |       |      |
+| ZcashOrchardAction::cmx()                  | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashOrchardAction::encrypted_note()       | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashOrchardAction::cv_net()               | 🔴    |  ✅ |  ✅  |       |  ✅  |
+| ZcashOrchardAction::authorization()        |       |     |      |       |      |
+| ZcashOrchardAction::to_instance()          |       |     |      |       |      |
+
+
+
+### ZcashOrchardValueCommitment
+
+* Original type: [orchard::value::ValueCommitment](https://docs.rs/orchard/0.3.0/orchard/value/struct.ValueCommitment.html)
+
+| Members                                  | Score | UDL | Code | Tests | Docs |
+| -----------------------------------------| ----- | --- | ---- | ----- | ---- |
+| ZcashOrchardValueCommitment::derive()    |       |     |      |      |      |
+| ZcashOrchardValueCommitment::from_bytes()|       |     |      |      |      |
+| ZcashOrchardValueCommitment::to_bytes()  | 🔴    |  ✅ |  ✅  |      |  ✅  |
+
 ## Enums
 
 ### ZcashScope
@@ -1121,6 +1183,11 @@ A pair of [ZcashDiversifierIndex](#zcashdiversifierindex) and [ZcashPaymentAddre
 ### ZcashTransactionSaplingMetadata
 
 A pair of [ZcashTransaction](#zcashtransaction) and [ZcashSaplingMetadata](#zcashsaplingmetadata)
+
+### TransmittedNoteCiphertext
+
+A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orchard/0.3.0/orchard/note/struct.TransmittedNoteCiphertext.html)
+
 ## Functions
 
 ### zcash_client_backend::encoding

--- a/STATUS.md
+++ b/STATUS.md
@@ -1028,8 +1028,8 @@ a tuple.
 | ZcashOrchardBundle::authorization()            |       |     |      |      |      |
 | ZcashOrchardBundle::authorizing_commitment()   |       |     |      |      |      |
 | ZcashOrchardBundle::binding_validating_key()   |       |     |      |      |      |
-| ZcashOrchardBundle::decrypt_output_with_key()  | 🔴    |  ✅ |  ✅  |      | ✅   |
-| ZcashOrchardBundle::decrypt_outputs_with_keys()| 🔴    |     |      |      |      |
+| ZcashOrchardBundle::decrypt_output_with_key()  | 🔴    |  ✅ |  ✅  |      |  ✅  |
+| ZcashOrchardBundle::decrypt_outputs_with_keys()| 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::flags()                    | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::value_balance()            | 🔴    |  ✅ |  ✅  |      |  ✅  |
 | ZcashOrchardBundle::verify_proof()             | 🔴    |  ✅ |  ✅  |      |  ✅  |
@@ -1206,7 +1206,11 @@ A 1:1 exposure of [orchard::note::TransmittedNoteCiphertext](https://docs.rs/orc
 
 ### ZcashOrchardBundleDecryptOutput
 
-A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) methods.
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) `decrypt_output_with_key()` method.
+
+### ZcashOrchardBundleDecryptOutputForKeys
+
+A dictionary for holding the response of some [ZcashOrchardBundle](#zcashorchardbundle-authorized) `decrypt_output_with_keys` method.
 
 ## Functions
 

--- a/lib/uniffi-zcash/Cargo.toml
+++ b/lib/uniffi-zcash/Cargo.toml
@@ -24,6 +24,7 @@ zcash_proofs = { version = "0.10.0", features= ["bundled-prover"] }
 orchard = {version= "0.3.0"}
 secp256k1 = {version = "0.21.3"}
 jubjub = {version = "0.9.0"}
+reddsa = "0.3.0"
 rand = "0.8.5"
 bs58 = "0.4.0"
 group = "0.12.0"

--- a/lib/uniffi-zcash/src/error.rs
+++ b/lib/uniffi-zcash/src/error.rs
@@ -1,7 +1,7 @@
 use std::{convert::Infallible, num::TryFromIntError};
 
 use orchard::zip32;
-use zcash_primitives::transaction::{self, fees};
+use zcash_primitives::transaction::{self, components::amount::BalanceError, fees};
 
 /// Zcash error.
 #[derive(Debug, thiserror::Error)]
@@ -65,6 +65,9 @@ pub enum ZcashError {
 
     #[error("Insufficient founds error: {amount}")]
     InsufficientFundsError { amount: u64 },
+
+    #[error("Balance error: {error:?}")]
+    BalanceError { error: BalanceError },
 
     #[error("Change required error: {amount}")]
     ChangeRequiredError { amount: u64 },
@@ -187,6 +190,12 @@ impl From<transaction::components::sapling::builder::Error> for ZcashError {
 impl From<orchard::builder::Error> for ZcashError {
     fn from(error: orchard::builder::Error) -> Self {
         ZcashError::OrchardBuilderError { error }
+    }
+}
+
+impl From<BalanceError> for ZcashError {
+    fn from(error: BalanceError) -> Self {
+        ZcashError::BalanceError { error }
     }
 }
 

--- a/lib/uniffi-zcash/src/orchard/action.rs
+++ b/lib/uniffi-zcash/src/orchard/action.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use orchard::{primitives::redpallas::Signature, Action};
+use reddsa::orchard::SpendAuth;
+
+use crate::{
+    ZcashExtractedNoteCommitment, ZcashOrchardNullifier, ZcashOrchardTransmittedNoteCiphertext,
+    ZcashOrchardValueCommitment,
+};
+
+/// An action applied to the global ledger.
+///
+/// Externally, this both creates a note (adding a commitment to the global ledger),
+/// and consumes some note created prior to this action (adding a nullifier to the
+/// global ledger).
+///
+/// Internally, this may both consume a note and create a note, or it may do only one of
+/// the two. TODO: Determine which is more efficient (circuit size vs bundle size).
+pub struct ZcashOrchardAction(Action<Signature<SpendAuth>>);
+
+impl ZcashOrchardAction {
+    /// Returns the nullifier of the note being spent.
+    pub fn nullifier(&self) -> Arc<ZcashOrchardNullifier> {
+        Arc::new(self.0.nullifier().into())
+    }
+
+    /// Returns the commitment to the new note being created.
+    pub fn cmx(&self) -> Arc<ZcashExtractedNoteCommitment> {
+        Arc::new(self.0.cmx().into())
+    }
+
+    /// Returns the encrypted note ciphertext.
+    pub fn encrypted_note(&self) -> ZcashOrchardTransmittedNoteCiphertext {
+        self.0.encrypted_note().into()
+    }
+
+    /// Returns the commitment to the net value created or consumed by this action.
+    pub fn cv_net(&self) -> Arc<ZcashOrchardValueCommitment> {
+        Arc::new(self.0.cv_net().into())
+    }
+}
+
+impl From<&Action<Signature<SpendAuth>>> for ZcashOrchardAction {
+    fn from(inner: &Action<Signature<SpendAuth>>) -> Self {
+        ZcashOrchardAction(inner.clone())
+    }
+}

--- a/lib/uniffi-zcash/src/orchard/bundle.rs
+++ b/lib/uniffi-zcash/src/orchard/bundle.rs
@@ -6,7 +6,7 @@ use orchard::{
 };
 use zcash_primitives::transaction::components::Amount;
 
-use crate::{ZcashAmount, ZcashAnchor, ZcashOrchardAction, ZcashResult};
+use crate::{ZcashAmount, ZcashAnchor, ZcashOrchardAction, ZcashResult, ZcashVerifyingKey};
 
 /// A bundle of actions to be applied to the ledger.
 pub struct ZcashOrchardBundle(Bundle<Authorized, Amount>);
@@ -37,6 +37,11 @@ impl ZcashOrchardBundle {
     /// Returns the root of the Orchard commitment tree that this bundle commits to.
     pub fn anchor(&self) -> Arc<ZcashAnchor> {
         Arc::new(self.0.anchor().into())
+    }
+
+    /// Verifies the proof for this bundle.
+    pub fn verify_proof(&self, key: &ZcashVerifyingKey) -> ZcashResult<()> {
+        self.0.verify_proof(&key.0).or(Err("Error verifying proof".into()))
     }
 }
 

--- a/lib/uniffi-zcash/src/orchard/bundle.rs
+++ b/lib/uniffi-zcash/src/orchard/bundle.rs
@@ -1,8 +1,8 @@
-use std::{sync::Arc};
+use std::sync::Arc;
 
 use orchard::{
     bundle::{Authorized, Flags},
-    keys::IncomingViewingKey,
+    keys::{IncomingViewingKey, OutgoingViewingKey},
     Address, Bundle, Note,
 };
 use zcash_primitives::transaction::components::Amount;
@@ -58,7 +58,7 @@ impl ZcashOrchardBundle {
         &self,
         action_idx: u64,
         ivk: &ZcashOrchardIncomingViewingKey,
-    ) -> ZcashResult<ZcashOrchardBundleDecryptOutput> {
+    ) -> ZcashResult<ZcashOrchardDecryptOutput> {
         match self
             .0
             .decrypt_output_with_key(action_idx.try_into()?, &ivk.0)
@@ -75,7 +75,7 @@ impl ZcashOrchardBundle {
     pub fn decrypt_output_with_keys(
         &self,
         ivks: Vec<Arc<ZcashOrchardIncomingViewingKey>>,
-    ) -> Vec<ZcashOrchardBundleDecryptOutputForKeys> {
+    ) -> Vec<ZcashOrchardDecryptOutputForIncomingKeys> {
         let keys = ivks
             .into_iter()
             .map(|f| f.as_ref().into())
@@ -94,7 +94,7 @@ impl ZcashOrchardBundle {
         &self,
         action_idx: u64,
         key: &ZcashOrchardOutgoingViewingKey,
-    ) -> ZcashResult<ZcashOrchardBundleDecryptOutput> {
+    ) -> ZcashResult<ZcashOrchardDecryptOutput> {
         match self
             .0
             .recover_output_with_ovk(action_idx.try_into()?, &key.0)
@@ -111,7 +111,7 @@ impl ZcashOrchardBundle {
     pub fn recover_outputs_with_ovks(
         &self,
         ovks: Vec<Arc<ZcashOrchardOutgoingViewingKey>>,
-    ) -> Vec<ZcashOrchardBundleDecryptOutputForOutgoingKeys> {
+    ) -> Vec<ZcashOrchardDecryptOutputForOutgoingKeys> {
         let keys = ovks
             .into_iter()
             .map(|key| key.as_ref().into())
@@ -130,13 +130,13 @@ impl From<&Bundle<Authorized, Amount>> for ZcashOrchardBundle {
     }
 }
 
-pub struct ZcashOrchardBundleDecryptOutput {
+pub struct ZcashOrchardDecryptOutput {
     pub note: Arc<ZcashOrchardNote>,
     pub address: Arc<ZcashOrchardAddress>,
     pub data: Vec<u8>,
 }
 
-impl From<(Note, Address, [u8; 512])> for ZcashOrchardBundleDecryptOutput {
+impl From<(Note, Address, [u8; 512])> for ZcashOrchardDecryptOutput {
     fn from((note, address, data): (Note, Address, [u8; 512])) -> Self {
         Self {
             note: Arc::new(note.into()),
@@ -146,7 +146,7 @@ impl From<(Note, Address, [u8; 512])> for ZcashOrchardBundleDecryptOutput {
     }
 }
 
-pub struct ZcashOrchardBundleDecryptOutputForKeys {
+pub struct ZcashOrchardDecryptOutputForIncomingKeys {
     pub val: u64,
     pub key: Arc<ZcashOrchardIncomingViewingKey>,
     pub note: Arc<ZcashOrchardNote>,
@@ -155,7 +155,7 @@ pub struct ZcashOrchardBundleDecryptOutputForKeys {
 }
 
 impl TryFrom<(usize, IncomingViewingKey, Note, Address, [u8; 512])>
-    for ZcashOrchardBundleDecryptOutputForKeys
+    for ZcashOrchardDecryptOutputForIncomingKeys
 {
     type Error = ZcashError;
     fn try_from(
@@ -171,7 +171,7 @@ impl TryFrom<(usize, IncomingViewingKey, Note, Address, [u8; 512])>
     }
 }
 
-pub struct ZcashOrchardBundleDecryptOutputForOutgoingKeys {
+pub struct ZcashOrchardDecryptOutputForOutgoingKeys {
     pub val: u64,
     pub key: Arc<ZcashOrchardOutgoingViewingKey>,
     pub note: Arc<ZcashOrchardNote>,
@@ -180,7 +180,7 @@ pub struct ZcashOrchardBundleDecryptOutputForOutgoingKeys {
 }
 
 impl TryFrom<(usize, OutgoingViewingKey, Note, Address, [u8; 512])>
-    for ZcashOrchardBundleDecryptOutputForOutgoingKeys
+    for ZcashOrchardDecryptOutputForOutgoingKeys
 {
     type Error = ZcashError;
     fn try_from(

--- a/lib/uniffi-zcash/src/orchard/bundle.rs
+++ b/lib/uniffi-zcash/src/orchard/bundle.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc};
 
 use orchard::{
     bundle::{Authorized, Flags},
@@ -9,7 +9,8 @@ use zcash_primitives::transaction::components::Amount;
 
 use crate::{
     ZcashAmount, ZcashAnchor, ZcashError, ZcashOrchardAction, ZcashOrchardAddress,
-    ZcashOrchardIncomingViewingKey, ZcashOrchardNote, ZcashResult, ZcashVerifyingKey,
+    ZcashOrchardIncomingViewingKey, ZcashOrchardNote, ZcashOrchardOutgoingViewingKey, ZcashResult,
+    ZcashVerifyingKey,
 };
 
 /// A bundle of actions to be applied to the ledger.
@@ -84,6 +85,23 @@ impl ZcashOrchardBundle {
             .into_iter()
             .map(|e| e.try_into().unwrap())
             .collect()
+    }
+
+    /// Attempts to decrypt the action at the specified index with the specified
+    /// outgoing viewing key, and returns the decrypted note plaintext contents
+    /// if successful.
+    pub fn recover_output_with_ovk(
+        &self,
+        action_idx: u64,
+        key: &ZcashOrchardOutgoingViewingKey,
+    ) -> ZcashResult<ZcashOrchardBundleDecryptOutput> {
+        match self
+            .0
+            .recover_output_with_ovk(action_idx.try_into()?, &key.0)
+        {
+            Some(result) => Ok(result.into()),
+            None => Err("Cannot recover output".into()),
+        }
     }
 }
 

--- a/lib/uniffi-zcash/src/orchard/bundle.rs
+++ b/lib/uniffi-zcash/src/orchard/bundle.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use orchard::{
+    bundle::{Authorized, Flags},
+    Bundle,
+};
+use zcash_primitives::transaction::components::Amount;
+
+use crate::{ZcashAmount, ZcashAnchor, ZcashOrchardAction, ZcashResult};
+
+/// A bundle of actions to be applied to the ledger.
+pub struct ZcashOrchardBundle(Bundle<Authorized, Amount>);
+
+impl ZcashOrchardBundle {
+    /// The list of actions that make up this bundle.
+    pub fn actions(&self) -> Vec<Arc<ZcashOrchardAction>> {
+        self.0
+            .actions()
+            .iter()
+            .map(|a| a.into())
+            .map(Arc::new)
+            .collect()
+    }
+
+    /// Returns the Orchard-specific transaction-level flags for this bundle.
+    pub fn flags(&self) -> Arc<ZcashOrchardFlags> {
+        Arc::new(self.0.flags().into())
+    }
+
+    /// Returns the net value moved into or out of the Orchard shielded pool.
+    ///
+    /// This is the sum of Orchard spends minus the sum Orchard outputs.
+    pub fn value_balance(&self) -> Arc<ZcashAmount> {
+        Arc::new(self.0.value_balance().into())
+    }
+
+    /// Returns the root of the Orchard commitment tree that this bundle commits to.
+    pub fn anchor(&self) -> Arc<ZcashAnchor> {
+        Arc::new(self.0.anchor().into())
+    }
+}
+
+impl From<&Bundle<Authorized, Amount>> for ZcashOrchardBundle {
+    fn from(inner: &Bundle<Authorized, Amount>) -> Self {
+        ZcashOrchardBundle(inner.clone())
+    }
+}
+
+/// Orchard-specific flags.
+pub struct ZcashOrchardFlags(Flags);
+
+impl ZcashOrchardFlags {
+    /// Construct a set of flags from its constituent parts
+    pub fn from_parts(spends_enabled: bool, outputs_enabled: bool) -> Self {
+        Flags::from_parts(spends_enabled, outputs_enabled).into()
+    }
+
+    /// Flag denoting whether Orchard spends are enabled in the transaction.
+    ///
+    /// If `false`, spent notes within [`Action`]s in the transaction's [`Bundle`] are
+    /// guaranteed to be dummy notes. If `true`, the spent notes may be either real or
+    /// dummy notes.
+    pub fn spends_enabled(&self) -> bool {
+        self.0.spends_enabled()
+    }
+
+    /// Flag denoting whether Orchard outputs are enabled in the transaction.
+    ///
+    /// If `false`, created notes within [`Action`]s in the transaction's [`Bundle`] are
+    /// guaranteed to be dummy notes. If `true`, the created notes may be either real or
+    /// dummy notes.
+    pub fn outputs_enabled(&self) -> bool {
+        self.0.outputs_enabled()
+    }
+
+    /// Serialize flags to a byte as defined in [Zcash Protocol Spec § 7.1: Transaction
+    /// Encoding And Consensus][txencoding].
+    ///
+    /// [txencoding]: https://zips.z.cash/protocol/protocol.pdf#txnencoding
+    pub fn to_byte(&self) -> u8 {
+        self.0.to_byte()
+    }
+
+    /// Parses flags from a single byte as defined in [Zcash Protocol Spec § 7.1:
+    /// Transaction Encoding And Consensus][txencoding].
+    ///
+    /// Returns `None` if unexpected bits are set in the flag byte.
+    ///
+    /// [txencoding]: https://zips.z.cash/protocol/protocol.pdf#txnencoding
+    pub fn from_byte(v: u8) -> ZcashResult<Self> {
+        match Flags::from_byte(v) {
+            Some(flags) => Ok(flags.into()),
+            None => Err("Error parsing flags bits".into()),
+        }
+    }
+}
+
+impl From<Flags> for ZcashOrchardFlags {
+    fn from(inner: Flags) -> Self {
+        ZcashOrchardFlags(inner)
+    }
+}
+
+impl From<&Flags> for ZcashOrchardFlags {
+    fn from(inner: &Flags) -> Self {
+        ZcashOrchardFlags(*inner)
+    }
+}

--- a/lib/uniffi-zcash/src/orchard/circuit.rs
+++ b/lib/uniffi-zcash/src/orchard/circuit.rs
@@ -1,8 +1,10 @@
 use orchard::circuit::{ProvingKey, VerifyingKey};
 
+/// The verifying key for the Orchard Action circuit.
 pub struct ZcashVerifyingKey(pub(crate) VerifyingKey);
 
 impl ZcashVerifyingKey {
+    /// Builds the verifying key.
     pub fn new() -> Self {
         VerifyingKey::build().into()
     }
@@ -20,9 +22,11 @@ impl Default for ZcashVerifyingKey {
     }
 }
 
+/// The proving key for the Orchard Action circuit.
 pub struct ZcashProvingKey(pub(crate) ProvingKey);
 
 impl ZcashProvingKey {
+    /// Builds the verifying key.
     pub fn new() -> Self {
         ProvingKey::build().into()
     }

--- a/lib/uniffi-zcash/src/orchard/circuit.rs
+++ b/lib/uniffi-zcash/src/orchard/circuit.rs
@@ -1,0 +1,41 @@
+use orchard::circuit::{ProvingKey, VerifyingKey};
+
+pub struct ZcashVerifyingKey(pub(crate) VerifyingKey);
+
+impl ZcashVerifyingKey {
+    pub fn new() -> Self {
+        VerifyingKey::build().into()
+    }
+}
+
+impl From<VerifyingKey> for ZcashVerifyingKey {
+    fn from(inner: VerifyingKey) -> Self {
+        ZcashVerifyingKey(inner)
+    }
+}
+
+impl Default for ZcashVerifyingKey {
+    fn default() -> Self {
+        ZcashVerifyingKey::new()
+    }
+}
+
+pub struct ZcashProvingKey(pub(crate) ProvingKey);
+
+impl ZcashProvingKey {
+    pub fn new() -> Self {
+        ProvingKey::build().into()
+    }
+}
+
+impl From<ProvingKey> for ZcashProvingKey {
+    fn from(inner: ProvingKey) -> Self {
+        ZcashProvingKey(inner)
+    }
+}
+
+impl Default for ZcashProvingKey {
+    fn default() -> Self {
+        ZcashProvingKey::new()
+    }
+}

--- a/lib/uniffi-zcash/src/orchard/keys/incoming_viewing_key.rs
+++ b/lib/uniffi-zcash/src/orchard/keys/incoming_viewing_key.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// This key is useful in situations where you only need the capability to detect inbound
 /// payments, such as merchant terminals.
-pub struct ZcashOrchardIncomingViewingKey(IncomingViewingKey);
+pub struct ZcashOrchardIncomingViewingKey(pub(crate) IncomingViewingKey);
 
 impl ZcashOrchardIncomingViewingKey {
     /// Serializes an Orchard incoming viewing key to its raw encoding as specified in [Zcash Protocol Spec § 5.6.4.3: Orchard Raw Incoming Viewing Keys][orchardrawinviewingkeys]

--- a/lib/uniffi-zcash/src/orchard/keys/incoming_viewing_key.rs
+++ b/lib/uniffi-zcash/src/orchard/keys/incoming_viewing_key.rs
@@ -61,3 +61,10 @@ impl From<IncomingViewingKey> for ZcashOrchardIncomingViewingKey {
         Self(key)
     }
 }
+
+
+impl From<&ZcashOrchardIncomingViewingKey> for IncomingViewingKey {
+    fn from(value: &ZcashOrchardIncomingViewingKey) -> Self {
+        value.0.clone()
+    }
+}

--- a/lib/uniffi-zcash/src/orchard/keys/outgoing_viewing_key.rs
+++ b/lib/uniffi-zcash/src/orchard/keys/outgoing_viewing_key.rs
@@ -4,7 +4,7 @@ use crate::{utils, ZcashResult};
 
 /// A key that provides the capability to recover outgoing transaction information from
 /// the block chain.
-pub struct ZcashOrchardOutgoingViewingKey(OutgoingViewingKey);
+pub struct ZcashOrchardOutgoingViewingKey(pub(crate) OutgoingViewingKey);
 
 impl From<OutgoingViewingKey> for ZcashOrchardOutgoingViewingKey {
     fn from(key: OutgoingViewingKey) -> Self {

--- a/lib/uniffi-zcash/src/orchard/mod.rs
+++ b/lib/uniffi-zcash/src/orchard/mod.rs
@@ -21,3 +21,6 @@ pub use self::bundle::*;
 
 mod action;
 pub use self::action::*;
+
+mod circuit;
+pub use self::circuit::*;

--- a/lib/uniffi-zcash/src/orchard/mod.rs
+++ b/lib/uniffi-zcash/src/orchard/mod.rs
@@ -15,3 +15,9 @@ pub use self::note::*;
 
 mod value;
 pub use self::value::*;
+
+mod bundle;
+pub use self::bundle::*;
+
+mod action;
+pub use self::action::*;

--- a/lib/uniffi-zcash/src/orchard/note/commitment.rs
+++ b/lib/uniffi-zcash/src/orchard/note/commitment.rs
@@ -42,6 +42,12 @@ impl ZcashExtractedNoteCommitment {
     }
 }
 
+impl From<&ExtractedNoteCommitment> for ZcashExtractedNoteCommitment {
+    fn from(inner: &ExtractedNoteCommitment) -> Self {
+        ZcashExtractedNoteCommitment(*inner)
+    }
+}
+
 impl From<&ZcashExtractedNoteCommitment> for ExtractedNoteCommitment {
     fn from(value: &ZcashExtractedNoteCommitment) -> Self {
         value.0

--- a/lib/uniffi-zcash/src/orchard/note/mod.rs
+++ b/lib/uniffi-zcash/src/orchard/note/mod.rs
@@ -4,7 +4,7 @@ pub use self::commitment::*;
 use std::sync::Arc;
 
 use orchard::{
-    note::{Nullifier, RandomSeed},
+    note::{Nullifier, RandomSeed, TransmittedNoteCiphertext},
     Note,
 };
 
@@ -90,6 +90,12 @@ impl From<Nullifier> for ZcashOrchardNullifier {
     }
 }
 
+impl From<&Nullifier> for ZcashOrchardNullifier {
+    fn from(inner: &Nullifier) -> Self {
+        ZcashOrchardNullifier(*inner)
+    }
+}
+
 impl From<&ZcashOrchardNullifier> for Nullifier {
     fn from(value: &ZcashOrchardNullifier) -> Self {
         value.0
@@ -127,5 +133,26 @@ impl From<RandomSeed> for ZcashOrchardRandomSeed {
 impl From<&ZcashOrchardRandomSeed> for RandomSeed {
     fn from(value: &ZcashOrchardRandomSeed) -> Self {
         value.0
+    }
+}
+
+/// An encrypted note.
+pub struct ZcashOrchardTransmittedNoteCiphertext {
+    /// The serialization of the ephemeral public key
+    pub epk_bytes: Vec<u8>, // 32 bytes
+    /// The encrypted note ciphertext
+    pub enc_ciphertext: Vec<u8>, // 580 bytes
+    /// An encrypted value that allows the holder of the outgoing cipher
+    /// key for the note to recover the note plaintext.
+    pub out_ciphertext: Vec<u8>, // 80 bytes
+}
+
+impl From<&TransmittedNoteCiphertext> for ZcashOrchardTransmittedNoteCiphertext {
+    fn from(value: &TransmittedNoteCiphertext) -> Self {
+        Self {
+            epk_bytes: value.epk_bytes.into(),
+            enc_ciphertext: value.enc_ciphertext.into(),
+            out_ciphertext: value.out_ciphertext.into(),
+        }
     }
 }

--- a/lib/uniffi-zcash/src/orchard/note/mod.rs
+++ b/lib/uniffi-zcash/src/orchard/note/mod.rs
@@ -138,13 +138,12 @@ impl From<&ZcashOrchardRandomSeed> for RandomSeed {
 
 /// An encrypted note.
 pub struct ZcashOrchardTransmittedNoteCiphertext {
-    /// The serialization of the ephemeral public key
-    pub epk_bytes: Vec<u8>, // 32 bytes
-    /// The encrypted note ciphertext
-    pub enc_ciphertext: Vec<u8>, // 580 bytes
-    /// An encrypted value that allows the holder of the outgoing cipher
-    /// key for the note to recover the note plaintext.
-    pub out_ciphertext: Vec<u8>, // 80 bytes
+    /// The serialization of the ephemeral public key (32 bytes).
+    pub epk_bytes: Vec<u8>,
+    /// The encrypted note ciphertext (580 bytes).
+    pub enc_ciphertext: Vec<u8>,
+    /// An encrypted value that allows the holder of the outgoing cipher key for the note to recover the note plaintext. (80 bytes)
+    pub out_ciphertext: Vec<u8>,
 }
 
 impl From<&TransmittedNoteCiphertext> for ZcashOrchardTransmittedNoteCiphertext {

--- a/lib/uniffi-zcash/src/orchard/tree.rs
+++ b/lib/uniffi-zcash/src/orchard/tree.rs
@@ -22,6 +22,13 @@ impl ZcashAnchor {
     }
 }
 
+
+impl From<&Anchor> for ZcashAnchor {
+    fn from(inner: &Anchor) -> Self {
+        ZcashAnchor(*inner)
+    }
+}
+
 impl From<Anchor> for ZcashAnchor {
     fn from(inner: Anchor) -> Self {
         ZcashAnchor(inner)

--- a/lib/uniffi-zcash/src/orchard/value.rs
+++ b/lib/uniffi-zcash/src/orchard/value.rs
@@ -1,4 +1,4 @@
-use orchard::value::NoteValue;
+use orchard::value::{NoteValue, ValueCommitment};
 
 /// The non-negative value of an individual Orchard note.
 pub struct ZcashOrchardNoteValue(NoteValue);
@@ -22,5 +22,19 @@ impl From<NoteValue> for ZcashOrchardNoteValue {
 impl From<&ZcashOrchardNoteValue> for NoteValue {
     fn from(value: &ZcashOrchardNoteValue) -> Self {
         value.0
+    }
+}
+
+pub struct ZcashOrchardValueCommitment(ValueCommitment);
+
+impl ZcashOrchardValueCommitment {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
+    }
+}
+
+impl From<&ValueCommitment> for ZcashOrchardValueCommitment {
+    fn from(inner: &ValueCommitment) -> Self {
+        ZcashOrchardValueCommitment(inner.clone())
     }
 }

--- a/lib/uniffi-zcash/src/udl/error.udl
+++ b/lib/uniffi-zcash/src/udl/error.udl
@@ -17,6 +17,7 @@ enum ZcashError {
   "OrchardBuilderError",
   "InsufficientFundsError",
   "ChangeRequiredError",
+  "BalanceError",
   "IOError",
   "Unknown",
 };

--- a/lib/uniffi-zcash/src/udl/orchard/action.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/action.udl
@@ -1,0 +1,10 @@
+interface ZcashOrchardAction {
+
+    ZcashOrchardNullifier nullifier();
+    
+    ZcashExtractedNoteCommitment cmx();
+    
+    ZcashOrchardTransmittedNoteCiphertext encrypted_note();
+    
+    ZcashOrchardValueCommitment cv_net();
+};

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -14,6 +14,9 @@ interface ZcashOrchardBundle {
     ZcashOrchardBundleDecryptOutput decrypt_output_with_key(u64 action_idx, [ByRef] ZcashOrchardIncomingViewingKey ivk);
 
     sequence<ZcashOrchardBundleDecryptOutputForKeys> decrypt_output_with_keys(sequence<ZcashOrchardIncomingViewingKey> ivks);
+
+    [Throws=ZcashError]
+    ZcashOrchardBundleDecryptOutput recover_output_with_ovk(u64 action_idx, [ByRef] ZcashOrchardOutgoingViewingKey ovk);
 };
 
 interface ZcashOrchardFlags {

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -7,6 +7,8 @@ interface ZcashOrchardBundle {
 
     ZcashAnchor anchor();
 
+    [Throws=ZcashError]
+    void verify_proof([ByRef] ZcashVerifyingKey key);
 };
 
 interface ZcashOrchardFlags {

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -17,6 +17,8 @@ interface ZcashOrchardBundle {
 
     [Throws=ZcashError]
     ZcashOrchardBundleDecryptOutput recover_output_with_ovk(u64 action_idx, [ByRef] ZcashOrchardOutgoingViewingKey ovk);
+
+    sequence<ZcashOrchardBundleDecryptOutputForOutgoingKeys> recover_outputs_with_ovks(sequence<ZcashOrchardOutgoingViewingKey> ivks);
 };
 
 interface ZcashOrchardFlags {
@@ -42,6 +44,14 @@ dictionary ZcashOrchardBundleDecryptOutput {
 dictionary ZcashOrchardBundleDecryptOutputForKeys {
     u64 val;
     ZcashOrchardIncomingViewingKey key;
+    ZcashOrchardNote note;
+    ZcashOrchardAddress address;
+    sequence<u8> data;
+};
+
+dictionary ZcashOrchardBundleDecryptOutputForOutgoingKeys {
+    u64 val;
+    ZcashOrchardOutgoingViewingKey key;
     ZcashOrchardNote note;
     ZcashOrchardAddress address;
     sequence<u8> data;

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -11,14 +11,14 @@ interface ZcashOrchardBundle {
     void verify_proof([ByRef] ZcashVerifyingKey key);
     
     [Throws=ZcashError]
-    ZcashOrchardBundleDecryptOutput decrypt_output_with_key(u64 action_idx, [ByRef] ZcashOrchardIncomingViewingKey ivk);
+    ZcashOrchardDecryptOutput decrypt_output_with_key(u64 action_idx, [ByRef] ZcashOrchardIncomingViewingKey ivk);
 
-    sequence<ZcashOrchardBundleDecryptOutputForKeys> decrypt_output_with_keys(sequence<ZcashOrchardIncomingViewingKey> ivks);
+    sequence<ZcashOrchardDecryptOutputForIncomingKeys> decrypt_output_with_keys(sequence<ZcashOrchardIncomingViewingKey> ivks);
 
     [Throws=ZcashError]
-    ZcashOrchardBundleDecryptOutput recover_output_with_ovk(u64 action_idx, [ByRef] ZcashOrchardOutgoingViewingKey ovk);
+    ZcashOrchardDecryptOutput recover_output_with_ovk(u64 action_idx, [ByRef] ZcashOrchardOutgoingViewingKey ovk);
 
-    sequence<ZcashOrchardBundleDecryptOutputForOutgoingKeys> recover_outputs_with_ovks(sequence<ZcashOrchardOutgoingViewingKey> ivks);
+    sequence<ZcashOrchardDecryptOutputForOutgoingKeys> recover_outputs_with_ovks(sequence<ZcashOrchardOutgoingViewingKey> ovks);
 };
 
 interface ZcashOrchardFlags {
@@ -35,13 +35,13 @@ interface ZcashOrchardFlags {
     u8 to_byte();
 };
 
-dictionary ZcashOrchardBundleDecryptOutput {
+dictionary ZcashOrchardDecryptOutput {
     ZcashOrchardNote note;
     ZcashOrchardAddress address;
     sequence<u8> data;
 };
 
-dictionary ZcashOrchardBundleDecryptOutputForKeys {
+dictionary ZcashOrchardDecryptOutputForIncomingKeys {
     u64 val;
     ZcashOrchardIncomingViewingKey key;
     ZcashOrchardNote note;
@@ -49,7 +49,7 @@ dictionary ZcashOrchardBundleDecryptOutputForKeys {
     sequence<u8> data;
 };
 
-dictionary ZcashOrchardBundleDecryptOutputForOutgoingKeys {
+dictionary ZcashOrchardDecryptOutputForOutgoingKeys {
     u64 val;
     ZcashOrchardOutgoingViewingKey key;
     ZcashOrchardNote note;

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -1,0 +1,24 @@
+interface ZcashOrchardBundle {
+    sequence<ZcashOrchardAction> actions();
+    
+    ZcashOrchardFlags flags();
+
+    ZcashAmount value_balance();
+
+    ZcashAnchor anchor();
+
+};
+
+interface ZcashOrchardFlags {
+    [Name=from_parts]
+    constructor(boolean spends_enabled, boolean outputs_enabled);
+
+    [Name=from_byte, Throws=ZcashError]
+    constructor(u8 v);
+
+    boolean spends_enabled();
+
+    boolean outputs_enabled();
+
+    u8 to_byte();
+};

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -12,6 +12,8 @@ interface ZcashOrchardBundle {
     
     [Throws=ZcashError]
     ZcashOrchardBundleDecryptOutput decrypt_output_with_key(u64 action_idx, [ByRef] ZcashOrchardIncomingViewingKey ivk);
+
+    sequence<ZcashOrchardBundleDecryptOutputForKeys> decrypt_output_with_keys(sequence<ZcashOrchardIncomingViewingKey> ivks);
 };
 
 interface ZcashOrchardFlags {
@@ -29,6 +31,14 @@ interface ZcashOrchardFlags {
 };
 
 dictionary ZcashOrchardBundleDecryptOutput {
+    ZcashOrchardNote note;
+    ZcashOrchardAddress address;
+    sequence<u8> data;
+};
+
+dictionary ZcashOrchardBundleDecryptOutputForKeys {
+    u64 val;
+    ZcashOrchardIncomingViewingKey key;
     ZcashOrchardNote note;
     ZcashOrchardAddress address;
     sequence<u8> data;

--- a/lib/uniffi-zcash/src/udl/orchard/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/bundle.udl
@@ -9,6 +9,9 @@ interface ZcashOrchardBundle {
 
     [Throws=ZcashError]
     void verify_proof([ByRef] ZcashVerifyingKey key);
+    
+    [Throws=ZcashError]
+    ZcashOrchardBundleDecryptOutput decrypt_output_with_key(u64 action_idx, [ByRef] ZcashOrchardIncomingViewingKey ivk);
 };
 
 interface ZcashOrchardFlags {
@@ -23,4 +26,10 @@ interface ZcashOrchardFlags {
     boolean outputs_enabled();
 
     u8 to_byte();
+};
+
+dictionary ZcashOrchardBundleDecryptOutput {
+    ZcashOrchardNote note;
+    ZcashOrchardAddress address;
+    sequence<u8> data;
 };

--- a/lib/uniffi-zcash/src/udl/orchard/circuit.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/circuit.udl
@@ -1,0 +1,7 @@
+interface ZcashVerifyingKey {
+    constructor();
+};
+
+interface ZcashProvingKey {
+    constructor();
+};

--- a/lib/uniffi-zcash/src/udl/orchard/note/note.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/note/note.udl
@@ -21,3 +21,12 @@ interface ZcashOrchardRandomSeed {
     constructor([ByRef] sequence<u8> data, ZcashOrchardNullifier rho);
     sequence<u8> to_bytes();
 };
+
+dictionary ZcashOrchardTransmittedNoteCiphertext {
+    
+    sequence<u8> epk_bytes;
+    
+    sequence<u8> enc_ciphertext;
+    
+    sequence<u8> out_ciphertext;
+};

--- a/lib/uniffi-zcash/src/udl/orchard/value.udl
+++ b/lib/uniffi-zcash/src/udl/orchard/value.udl
@@ -2,3 +2,7 @@ interface ZcashOrchardNoteValue {
     [Name=from_raw]
     constructor(u64 value);
 };
+
+interface ZcashOrchardValueCommitment {
+   sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/note/nullifier.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/note/nullifier.udl
@@ -1,0 +1,3 @@
+interface ZcashSaplingNullifier {
+   sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/redjubjub.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/redjubjub.udl
@@ -1,0 +1,4 @@
+interface ZcashSaplingPublicKey {
+   [Throws=ZcashError] 
+   sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/value_commitment.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/sapling/value_commitment.udl
@@ -1,0 +1,3 @@
+interface ZcashSaplingValueCommitment {
+   sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/bundle.udl
@@ -1,0 +1,8 @@
+interface ZcashSaplingBundle {
+
+   sequence<ZcashSaplingSpendDescription> shielded_spends();
+   
+   sequence<ZcashSaplingOutputDescription> shielded_outputs();
+   
+   ZcashAmount value_balance();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/output_description.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/output_description.udl
@@ -1,0 +1,5 @@
+interface ZcashSaplingOutputDescription {
+   ZcashSaplingValueCommitment cv();
+
+   ZcashSaplingExtractedNoteCommitment cmu();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/spend_description.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/components/sapling/spend_description.udl
@@ -1,0 +1,10 @@
+interface ZcashSaplingSpendDescription {
+    
+    ZcashSaplingValueCommitment cv();
+
+    sequence<u8> anchor();
+    
+    ZcashSaplingNullifier nullifier();
+
+    ZcashSaplingPublicKey rk();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -49,6 +49,14 @@ interface ZcashTransaction {
     
     [Name=from_bytes, Throws=ZcashError]
     constructor([ByRef] sequence<u8> data, ZcashBranchId consensus_branch_id);
+
+    ZcashTxVersion version();
+
+    ZcashBranchId consensus_branch_id();
+
+    u32 lock_time();
+
+    ZcashBlockHeight expiry_height();
 };
 
 dictionary ZcashTransactionAndSaplingMetadata {

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -84,3 +84,37 @@ interface ZcashOrchardTransactionBuilder {
        sequence<u8> sighash
     );
 };
+
+[Enum]
+interface ZcashTxVersionSelection {
+    Sprout(u32 v);
+    Overwinter();
+    Sapling();
+    Zip225();
+};
+
+interface ZcashTxVersion {
+
+    ZcashTxVersionSelection selection();
+    
+    [Name=from_bytes, Throws=ZcashError]
+    constructor([ByRef] sequence<u8> data);
+
+    [Name=suggested_for_branch]
+    constructor(ZcashBranchId consensus_branch_id);
+
+    u32 header();
+
+    u32 version_group_id();
+
+    [Throws=ZcashError]
+    sequence<u8> to_bytes();
+
+    boolean has_sprout();
+
+    boolean has_overwinter();
+
+    boolean has_sapling();
+
+    boolean has_orchard();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -63,6 +63,8 @@ interface ZcashTransaction {
     ZcashTransparentBundle? transparent_bundle();
     
     ZcashSaplingBundle? sapling_bundle();
+    
+    ZcashOrchardBundle? orchard_bundle();
 };
 
 interface ZcashTxId {

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -50,6 +50,8 @@ interface ZcashTransaction {
     [Name=from_bytes, Throws=ZcashError]
     constructor([ByRef] sequence<u8> data, ZcashBranchId consensus_branch_id);
 
+    ZcashTxId txid();
+
     ZcashTxVersion version();
 
     ZcashBranchId consensus_branch_id();
@@ -57,6 +59,13 @@ interface ZcashTransaction {
     u32 lock_time();
 
     ZcashBlockHeight expiry_height();
+};
+
+interface ZcashTxId {
+    [Name=from_bytes, Throws=ZcashError]
+    constructor([ByRef] sequence<u8> data);
+    [Throws=ZcashError]
+    sequence<u8> to_bytes();
 };
 
 dictionary ZcashTransactionAndSaplingMetadata {

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -61,6 +61,8 @@ interface ZcashTransaction {
     ZcashBlockHeight expiry_height();
 
     ZcashTransparentBundle? transparent_bundle();
+    
+    ZcashSaplingBundle? sapling_bundle();
 };
 
 interface ZcashTxId {

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -60,6 +60,9 @@ interface ZcashTransaction {
 
     ZcashBlockHeight expiry_height();
 
+    // [Throws=ZcashError]
+    // ZcashAmount fee_paid();
+
     ZcashTransparentBundle? transparent_bundle();
     
     ZcashSaplingBundle? sapling_bundle();

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -59,6 +59,8 @@ interface ZcashTransaction {
     u32 lock_time();
 
     ZcashBlockHeight expiry_height();
+
+    ZcashTransparentBundle? transparent_bundle();
 };
 
 interface ZcashTxId {

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transparent/bundle.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transparent/bundle.udl
@@ -1,0 +1,10 @@
+interface ZcashTransparentBundle {
+    boolean is_coinbase();
+
+    sequence<ZcashTxIn> vin();
+
+    sequence<ZcashTxOut> vout();
+
+    // [Throws=ZcashError]
+    // ZcashAmount value_balance();
+};

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transparent/tx_in.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transparent/tx_in.udl
@@ -1,0 +1,4 @@
+interface ZcashTxIn {
+    [Throws=ZcashError]
+    sequence<u8> to_bytes();
+};

--- a/lib/uniffi-zcash/src/zcash_primitives/consensus/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/consensus/mod.rs
@@ -24,6 +24,12 @@ impl From<&ZcashBlockHeight> for BlockHeight {
     }
 }
 
+impl From<BlockHeight> for ZcashBlockHeight {
+    fn from(inner: BlockHeight) -> Self {
+        ZcashBlockHeight(inner)
+    }
+}
+
 pub enum ZcashBranchId {
     /// The consensus rules at the launch of Zcash.
     Sprout,
@@ -51,6 +57,20 @@ impl From<ZcashBranchId> for BranchId {
             ZcashBranchId::Heartwood => BranchId::Heartwood,
             ZcashBranchId::Canopy => BranchId::Canopy,
             ZcashBranchId::Nu5 => BranchId::Nu5,
+        }
+    }
+}
+
+impl From<BranchId> for ZcashBranchId {
+    fn from(value: BranchId) -> Self {
+        match value {
+            BranchId::Sprout => ZcashBranchId::Sprout,
+            BranchId::Overwinter => ZcashBranchId::Overwinter,
+            BranchId::Sapling => ZcashBranchId::Sapling,
+            BranchId::Blossom => ZcashBranchId::Blossom,
+            BranchId::Heartwood => ZcashBranchId::Heartwood,
+            BranchId::Canopy => ZcashBranchId::Canopy,
+            BranchId::Nu5 => ZcashBranchId::Nu5,
         }
     }
 }

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/mod.rs
@@ -18,3 +18,6 @@ pub use self::note::*;
 
 mod tree;
 pub use self::tree::*;
+
+mod redjubjub;
+pub use self::redjubjub::*;

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/note/commitment.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/note/commitment.rs
@@ -32,3 +32,9 @@ impl From<ExtractedNoteCommitment> for ZcashSaplingExtractedNoteCommitment {
         ZcashSaplingExtractedNoteCommitment(inner)
     }
 }
+
+impl From<&ExtractedNoteCommitment> for ZcashSaplingExtractedNoteCommitment {
+    fn from(inner: &ExtractedNoteCommitment) -> Self {
+        ZcashSaplingExtractedNoteCommitment(*inner)
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/note/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/note/mod.rs
@@ -1,6 +1,9 @@
 mod commitment;
 pub use self::commitment::*;
 
+mod nullifier;
+pub use self::nullifier::*;
+
 use crate::{
     utils::cast_slice, ZcashError, ZcashJubjubFr, ZcashPaymentAddress, ZcashResult,
     ZcashSaplingNoteValue,

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/note/nullifier.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/note/nullifier.rs
@@ -1,0 +1,15 @@
+use zcash_primitives::sapling::Nullifier;
+
+pub struct ZcashSaplingNullifier(Nullifier);
+
+impl ZcashSaplingNullifier {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl From<&Nullifier> for ZcashSaplingNullifier {
+    fn from(inner: &Nullifier) -> Self {
+        ZcashSaplingNullifier(*inner)
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/redjubjub.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/redjubjub.rs
@@ -1,0 +1,19 @@
+use zcash_primitives::sapling::redjubjub::PublicKey;
+
+use crate::ZcashResult;
+
+pub struct ZcashSaplingPublicKey(PublicKey);
+
+impl ZcashSaplingPublicKey {
+    pub fn to_bytes(&self) -> ZcashResult<Vec<u8>> {
+        let mut data = Vec::with_capacity(32);
+        self.0.write(&mut data)?;
+        Ok(data)
+    }
+}
+
+impl From<&PublicKey> for ZcashSaplingPublicKey {
+    fn from(inner: &PublicKey) -> Self {
+        ZcashSaplingPublicKey(inner.clone())
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/sapling/value/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/sapling/value/mod.rs
@@ -1,2 +1,18 @@
 mod note;
+use zcash_primitives::sapling::value::ValueCommitment;
+
 pub use self::note::*;
+
+pub struct ZcashSaplingValueCommitment(ValueCommitment);
+
+impl ZcashSaplingValueCommitment {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
+    }
+}
+
+impl From<&ValueCommitment> for ZcashSaplingValueCommitment {
+    fn from(inner: &ValueCommitment) -> Self {
+        ZcashSaplingValueCommitment(inner.clone())
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/components/amount.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/components/amount.rs
@@ -30,6 +30,12 @@ impl From<Amount> for ZcashAmount {
     }
 }
 
+impl From<&Amount> for ZcashAmount {
+    fn from(value: &Amount) -> Self {
+        ZcashAmount(*value)
+    }
+}
+
 impl From<ZcashAmount> for Amount {
     fn from(value: ZcashAmount) -> Self {
         value.0

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/components/sapling/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/components/sapling/mod.rs
@@ -1,2 +1,98 @@
 mod builder;
 pub use self::builder::*;
+
+
+use std::sync::Arc;
+
+use zcash_primitives::transaction::components::{
+    sapling::{Authorized, Bundle, GrothProofBytes, SpendDescription},
+    OutputDescription,
+};
+
+use crate::{
+    ZcashAmount, ZcashSaplingExtractedNoteCommitment, ZcashSaplingNullifier, ZcashSaplingPublicKey,
+    ZcashSaplingValueCommitment,
+};
+
+pub struct ZcashSaplingBundle(Bundle<Authorized>);
+
+impl ZcashSaplingBundle {
+    /// Returns the list of spends in this bundle.
+    pub fn shielded_spends(&self) -> Vec<Arc<ZcashSaplingSpendDescription>> {
+        self.0
+            .shielded_spends()
+            .iter()
+            .map(|s| Arc::new(s.into()))
+            .collect()
+    }
+
+    /// Returns the list of outputs in this bundle.
+    pub fn shielded_outputs(&self) -> Vec<Arc<ZcashSaplingOutputDescription>> {
+        self.0
+            .shielded_outputs()
+            .iter()
+            .map(|o| Arc::new(o.into()))
+            .collect()
+    }
+
+    /// Returns the net value moved into or out of the Sapling shielded pool.
+    ///
+    /// This is the sum of Sapling spends minus the sum of Sapling outputs.
+    pub fn value_balance(&self) -> Arc<ZcashAmount> {
+        Arc::new(self.0.value_balance().into())
+    }
+}
+
+impl From<&Bundle<Authorized>> for ZcashSaplingBundle {
+    fn from(inner: &Bundle<Authorized>) -> Self {
+        ZcashSaplingBundle(inner.clone())
+    }
+}
+
+pub struct ZcashSaplingSpendDescription(SpendDescription<Authorized>);
+
+impl ZcashSaplingSpendDescription {
+    /// Returns the commitment to the value consumed by this spend.
+    pub fn cv(&self) -> Arc<ZcashSaplingValueCommitment> {
+        Arc::new(self.0.cv().into())
+    }
+
+    /// Returns the root of the Sapling commitment tree that this spend commits to.
+    pub fn anchor(&self) -> Vec<u8> {
+        self.0.anchor().to_bytes().to_vec()
+    }
+
+    /// Returns the nullifier of the note being spent.
+    pub fn nullifier(&self) -> Arc<ZcashSaplingNullifier> {
+        Arc::new(self.0.nullifier().into())
+    }
+
+    /// Returns the randomized verification key for the note being spent.
+    pub fn rk(&self) -> Arc<ZcashSaplingPublicKey> {
+        Arc::new(self.0.rk().into())
+    }
+}
+
+impl From<&SpendDescription<Authorized>> for ZcashSaplingSpendDescription {
+    fn from(inner: &SpendDescription<Authorized>) -> Self {
+        ZcashSaplingSpendDescription(inner.clone())
+    }
+}
+
+pub struct ZcashSaplingOutputDescription(OutputDescription<GrothProofBytes>); // Looks like GrothProofBytes corresponds to the authorized state proof.
+
+impl ZcashSaplingOutputDescription {
+    pub fn cv(&self) -> Arc<ZcashSaplingValueCommitment> {
+        Arc::new(self.0.cv().into())
+    }
+
+    pub fn cmu(&self) -> Arc<ZcashSaplingExtractedNoteCommitment> {
+        Arc::new(self.0.cmu().into())
+    }
+}
+
+impl From<&OutputDescription<GrothProofBytes>> for ZcashSaplingOutputDescription {
+    fn from(inner: &OutputDescription<GrothProofBytes>) -> Self {
+        ZcashSaplingOutputDescription(inner.clone())
+    }
+}

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/components/transparent.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/components/transparent.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use zcash_primitives::transaction::components::{OutPoint, TxOut};
+use zcash_primitives::transaction::components::{
+    transparent::{Authorized, Bundle, TxIn}, OutPoint, TxOut,
+};
 
 use crate::{utils::cast_slice, ZcashAmount, ZcashResult, ZcashScript, ZcashTransparentAddress};
 
@@ -64,5 +66,56 @@ impl From<ZcashTxOut> for TxOut {
 impl From<&ZcashTxOut> for TxOut {
     fn from(value: &ZcashTxOut) -> Self {
         value.0.clone()
+    }
+}
+
+impl From<&TxOut> for ZcashTxOut {
+    fn from(inner: &TxOut) -> Self {
+        ZcashTxOut(inner.clone())
+    }
+}
+
+pub struct ZcashTxIn(TxIn<Authorized>);
+
+impl ZcashTxIn {
+    pub fn to_bytes(&self) -> ZcashResult<Vec<u8>> {
+        let mut data = Vec::new();
+        self.0.write(&mut data)?;
+        Ok(data)
+    }
+}
+
+impl From<&TxIn<Authorized>> for ZcashTxIn {
+    fn from(inner: &TxIn<Authorized>) -> Self {
+        ZcashTxIn(inner.clone())
+    }
+}
+
+pub struct ZcashTransparentBundle(Bundle<Authorized>);
+
+impl ZcashTransparentBundle {
+    pub fn vout(&self) -> Vec<Arc<ZcashTxOut>> {
+        self.0.vout.iter().map(|o| Arc::new(o.into())).collect()
+    }
+
+    pub fn vin(&self) -> Vec<Arc<ZcashTxIn>> {
+        self.0.vin.iter().map(|i| Arc::new(i.into())).collect()
+    }
+
+    /// Returns `true` if this bundle matches the definition of a coinbase transaction.
+    ///
+    /// Note that this is defined purely in terms of the transparent transaction part. The
+    /// consensus rules enforce additional rules on the shielded parts (namely, that they
+    /// don't have any inputs) of transactions with a transparent part that matches this
+    /// definition.
+    pub fn is_coinbase(&self) -> bool {
+        self.0.is_coinbase()
+    }
+
+}
+
+impl From<&Bundle<Authorized>> for ZcashTransparentBundle {
+    fn from(inner: &Bundle<Authorized>) -> Self {
+        ZcashTransparentBundle(inner.clone())
     }
 }

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/components/transparent.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/components/transparent.rs
@@ -112,6 +112,20 @@ impl ZcashTransparentBundle {
         self.0.is_coinbase()
     }
 
+    // /// The amount of value added to or removed from the transparent pool by the action of this
+    // /// bundle. A positive value represents that the containing transaction has funds being
+    // /// transferred out of the transparent pool into shielded pools or to fees; a negative value
+    // /// means that the containing transaction has funds being transferred into the transparent pool
+    // /// from the shielded pools.
+    // pub fn value_balance(&self) -> ZcashResult<Arc<ZcashAmount>> {
+    //     match self
+    //         .0
+    //         .value_balance::<BalanceError, _>(|_| Ok(Amount::zero()))
+    //     {
+    //         Ok(amount) => Ok(Arc::new(amount.into())),
+    //         Err(err) => Err(err.into()),
+    //     }
+    // }
 }
 
 impl From<&Bundle<Authorized>> for ZcashTransparentBundle {

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -276,11 +276,11 @@ impl ZcashTransaction {
     // }
 
     pub fn transparent_bundle(&self) -> Option<Arc<ZcashTransparentBundle>> {
-        self.0.transparent_bundle().map(|b| Arc::new(b.into()))  
+        self.0.transparent_bundle().map(|b| b.into()).map(Arc::new)
     }
 
     pub fn sapling_bundle(&self) -> Option<Arc<ZcashSaplingBundle>> {
-        self.0.sapling_bundle().map(|b| Arc::new(b.into()))  
+        self.0.sapling_bundle().map(|b| b.into()).map(Arc::new)
     }
 
     pub fn orchard_bundle(&self) -> Option<Arc<ZcashOrchardBundle>> {

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -244,6 +244,22 @@ impl ZcashTransaction {
         let tx = Transaction::read(data, consensus_branch_id.into())?;
         Ok(tx.into())
     }
+
+    pub fn version(&self) -> Arc<ZcashTxVersion> {
+        Arc::new(self.0.version().into())
+    }
+
+    pub fn consensus_branch_id(&self) -> ZcashBranchId {
+        self.0.consensus_branch_id().into()
+    }
+
+    pub fn lock_time(&self) -> u32 {
+        self.0.lock_time()
+    }
+
+    pub fn expiry_height(&self) -> Arc<ZcashBlockHeight> {
+        Arc::new(self.0.expiry_height().into())
+    }
 }
 
 impl From<Transaction> for ZcashTransaction {

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -13,6 +13,7 @@ use orchard::{
     keys::{SpendAuthorizingKey, SpendingKey},
     value::NoteValue,
 };
+use zcash_primitives::transaction::components::amount::BalanceError;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::{
     consensus::BranchId,
@@ -264,6 +265,14 @@ impl ZcashTransaction {
 
     pub fn expiry_height(&self) -> Arc<ZcashBlockHeight> {
         Arc::new(self.0.expiry_height().into())
+    }
+
+    /// Returns the total fees paid by the transaction, given a function that can be used to
+    /// retrieve the value of previous transactions' transparent outputs that are being spent in
+    /// this transaction.
+    pub fn fee_paid(&self) -> ZcashResult<Arc<ZcashAmount>> {
+        let amount = self.0.fee_paid::<BalanceError, _>(|_| Ok(Amount::zero()))?;
+        Ok(Arc::new(amount.into()))
     }
 }
 

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -13,6 +13,7 @@ use orchard::{
     keys::{SpendAuthorizingKey, SpendingKey},
     value::NoteValue,
 };
+use zcash_primitives::transaction::TxId;
 use zcash_primitives::{
     consensus::BranchId,
     transaction::{
@@ -245,6 +246,10 @@ impl ZcashTransaction {
         Ok(tx.into())
     }
 
+    pub fn txid(&self) -> Arc<ZcashTxId> {
+        Arc::new(self.0.txid().into())
+    }
+
     pub fn version(&self) -> Arc<ZcashTxVersion> {
         Arc::new(self.0.version().into())
     }
@@ -278,6 +283,26 @@ impl From<(Transaction, SaplingMetadata)> for ZcashTransactionAndSaplingMetadata
             transaction: Arc::new(transaction.into()),
             sapling_metadata: Arc::new(sapling_metadata.into()),
         }
+    }
+}
+
+pub struct ZcashTxId(TxId);
+
+impl ZcashTxId {
+    pub fn from_bytes(data: &[u8]) -> ZcashResult<Self> {
+        Ok(TxId::from_bytes(cast_slice(data)?).into())
+    }
+
+    pub fn to_bytes(&self) -> ZcashResult<Vec<u8>> {
+        let mut data = Vec::with_capacity(32);
+        self.0.write(&mut data)?;
+        Ok(data)
+    }
+}
+
+impl From<TxId> for ZcashTxId {
+    fn from(inner: TxId) -> Self {
+        ZcashTxId(inner)
     }
 }
 

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -13,7 +13,6 @@ use orchard::{
     keys::{SpendAuthorizingKey, SpendingKey},
     value::NoteValue,
 };
-use zcash_primitives::transaction::components::amount::BalanceError;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::{
     consensus::BranchId,
@@ -270,9 +269,8 @@ impl ZcashTransaction {
     /// Returns the total fees paid by the transaction, given a function that can be used to
     /// retrieve the value of previous transactions' transparent outputs that are being spent in
     /// this transaction.
-    pub fn fee_paid(&self) -> ZcashResult<Arc<ZcashAmount>> {
-        let amount = self.0.fee_paid::<BalanceError, _>(|_| Ok(Amount::zero()))?;
-        Ok(Arc::new(amount.into()))
+    pub fn transparent_bundle(&self) -> Option<Arc<ZcashTransparentBundle>> {
+        self.0.transparent_bundle().map(|b| Arc::new(b.into()))  
     }
 }
 

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -274,6 +274,7 @@ impl ZcashTransaction {
     //     let amount = self.0.fee_paid::<BalanceError, _>(|_| Ok(Amount::zero()))?;
     //     Ok(Arc::new(amount.into()))
     // }
+    // TODO: investigate alternative ways of exposing this to FFI, as it accepts a closure as parameter.
 
     pub fn transparent_bundle(&self) -> Option<Arc<ZcashTransparentBundle>> {
         self.0.transparent_bundle().map(|b| b.into()).map(Arc::new)

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -23,6 +23,7 @@ use zcash_primitives::{
     },
 };
 
+use crate::ZcashOrchardBundle;
 use crate::{
     utils::cast_slice, SecpSecretKey, ZcashAnchor, ZcashBlockHeight, ZcashBranchId,
     ZcashConsensusParameters, ZcashDiversifier, ZcashError, ZcashExtendedSpendingKey,
@@ -280,6 +281,10 @@ impl ZcashTransaction {
 
     pub fn sapling_bundle(&self) -> Option<Arc<ZcashSaplingBundle>> {
         self.0.sapling_bundle().map(|b| Arc::new(b.into()))  
+    }
+
+    pub fn orchard_bundle(&self) -> Option<Arc<ZcashOrchardBundle>> {
+        self.0.orchard_bundle().map(|b| b.into()).map(Arc::new)
     }
 }
 

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -277,6 +277,10 @@ impl ZcashTransaction {
     pub fn transparent_bundle(&self) -> Option<Arc<ZcashTransparentBundle>> {
         self.0.transparent_bundle().map(|b| Arc::new(b.into()))  
     }
+
+    pub fn sapling_bundle(&self) -> Option<Arc<ZcashSaplingBundle>> {
+        self.0.sapling_bundle().map(|b| Arc::new(b.into()))  
+    }
 }
 
 impl From<Transaction> for ZcashTransaction {

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -269,6 +269,11 @@ impl ZcashTransaction {
     /// Returns the total fees paid by the transaction, given a function that can be used to
     /// retrieve the value of previous transactions' transparent outputs that are being spent in
     /// this transaction.
+    // pub fn fee_paid(&self) -> ZcashResult<Arc<ZcashAmount>> {
+    //     let amount = self.0.fee_paid::<BalanceError, _>(|_| Ok(Amount::zero()))?;
+    //     Ok(Arc::new(amount.into()))
+    // }
+
     pub fn transparent_bundle(&self) -> Option<Arc<ZcashTransparentBundle>> {
         self.0.transparent_bundle().map(|b| Arc::new(b.into()))  
     }


### PR DESCRIPTION
This PR is part of #36 (See it for more context). It aims to implement the most useful API methods/types for inspecting
transactions. That includeded support for inspecting the general transaction methods, plus the the bundles for `Transparent`, `Sapling` and `Orchard`.

**Review tip**: Go through each commit. Do it incrementally.
