### PR TITLE
Pass Flags as parameter in builder

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -552,7 +552,7 @@ Original type: [zcash_primitives::sapling::keys::OutgoingViewingKey](https://doc
 | -------------------------------------------------------- | ----- | --- | ---- | ----- | ---- |
 | ZcashOrchardTransactionBuilder::new()                    |   🔴  | ✅  | ✅   | ✅    |  ✅  |
 | ZcashOrchardTransactionBuilder::add_spend()              |   🔴  | ✅  | ✅   | ✅    |  ✅  |
-| ZcashOrchardTransactionBuilder::add_output()             |   🔴  | ✅  | ✅   | ✅    |  ✅  |
+| ZcashOrchardTransactionBuilder::add_recipient()             |   🔴  | ✅  | ✅   | ✅    |  ✅  |
 | ZcashOrchardTransactionBuilder::build()                  |   🔴  | ✅  | ✅   | ✅    |  ✅  |
 
 ### ZcashTransaction

--- a/lib/uniffi-zcash-test/src/test_data/mod.rs
+++ b/lib/uniffi-zcash-test/src/test_data/mod.rs
@@ -59,5 +59,5 @@ pub(crate) fn store_bytes<W: Write>(
     label: &str,
     data: &[u8],
 ) -> Result<(), std::io::Error> {
-    writeln!(file, "{}", format_bytes(label, &data))
+    writeln!(file, "{}", format_bytes(label, data))
 }

--- a/lib/uniffi-zcash/src/orchard/bundle.rs
+++ b/lib/uniffi-zcash/src/orchard/bundle.rs
@@ -245,6 +245,12 @@ impl ZcashOrchardFlags {
     }
 }
 
+impl From<&ZcashOrchardFlags> for Flags {
+    fn from(value: &ZcashOrchardFlags) -> Self {
+        value.0
+    }
+}
+
 impl From<Flags> for ZcashOrchardFlags {
     fn from(inner: Flags) -> Self {
         ZcashOrchardFlags(inner)

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -87,7 +87,8 @@ interface ZcashOrchardTransactionBuilder {
         ZcashConsensusParameters parameters, 
         ZcashBlockHeight target_height, 
         ZcashBlockHeight expiry_height,
-        ZcashAnchor anchor
+        ZcashAnchor anchor,
+        ZcashOrchardFlags flags
     );
 
     void add_spend(

--- a/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
+++ b/lib/uniffi-zcash/src/udl/zcash_primitives/transaction/transaction.udl
@@ -98,8 +98,8 @@ interface ZcashOrchardTransactionBuilder {
     );
     
     [Throws=ZcashError]
-    void add_output(
-        ZcashOrchardOutgoingViewingKey ovk,
+    void add_recipient(
+        ZcashOrchardOutgoingViewingKey? ovk,
         ZcashOrchardAddress recipient,
         u64 value,
         sequence<u8>? memo

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -366,9 +366,9 @@ impl ZcashOrchardTransactionBuilder {
         self.spends.write().unwrap().push((fvk, note, merkle_path))
     }
 
-    pub fn add_output(
+    pub fn add_recipient(
         &self,
-        ovk: Arc<ZcashOrchardOutgoingViewingKey>,
+        ovk: Option<Arc<ZcashOrchardOutgoingViewingKey>>,
         recipient: Arc<ZcashOrchardAddress>,
         value: u64,
         memo: Option<Vec<u8>>,
@@ -413,7 +413,7 @@ impl ZcashOrchardTransactionBuilder {
             .iter()
             .try_for_each(|(ovk, recipient, value, memo)| {
                 builder.add_recipient(
-                    Some(ovk.as_ref().into()),
+                    ovk.clone().map(|k| k.as_ref().into()),
                     recipient.as_ref().into(),
                     NoteValue::from_raw(*value),
                     *memo,
@@ -471,7 +471,7 @@ type OrchardSpends = RwLock<
 
 type OrchardOutputs = RwLock<
     Vec<(
-        Arc<ZcashOrchardOutgoingViewingKey>,
+        Option<Arc<ZcashOrchardOutgoingViewingKey>>,
         Arc<ZcashOrchardAddress>,
         u64,
         Option<[u8; 512]>,

--- a/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
+++ b/lib/uniffi-zcash/src/zcash_primitives/transaction/mod.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, RwLock};
 use hdwallet::rand_core::OsRng;
 use orchard::{
     builder::{InProgress, Unauthorized, Unproven},
-    bundle::Flags,
     keys::{SpendAuthorizingKey, SpendingKey},
     value::NoteValue,
 };
@@ -24,6 +23,7 @@ use zcash_primitives::{
 };
 
 use crate::ZcashOrchardBundle;
+use crate::ZcashOrchardFlags;
 use crate::{
     utils::cast_slice, SecpSecretKey, ZcashAnchor, ZcashBlockHeight, ZcashBranchId,
     ZcashConsensusParameters, ZcashDiversifier, ZcashError, ZcashExtendedSpendingKey,
@@ -333,6 +333,7 @@ pub struct ZcashOrchardTransactionBuilder {
     target_height: Arc<ZcashBlockHeight>,
     expiry_height: Arc<ZcashBlockHeight>,
     anchor: Arc<ZcashAnchor>,
+    flags: Arc<ZcashOrchardFlags>,
     spends: OrchardSpends,
     outputs: OrchardOutputs,
 }
@@ -343,12 +344,14 @@ impl ZcashOrchardTransactionBuilder {
         target_height: Arc<ZcashBlockHeight>,
         expiry_height: Arc<ZcashBlockHeight>,
         anchor: Arc<ZcashAnchor>,
+        flags: Arc<ZcashOrchardFlags>
     ) -> Self {
         Self {
             parameters,
             target_height,
             expiry_height,
             anchor,
+            flags,
             spends: RwLock::new(Vec::new()),
             outputs: RwLock::new(Vec::new()),
         }
@@ -388,7 +391,7 @@ impl ZcashOrchardTransactionBuilder {
         sighash: Vec<u8>,
     ) -> ZcashResult<Arc<ZcashTransaction>> {
         let mut builder = orchard::builder::Builder::new(
-            Flags::from_parts(true, true),
+            self.flags.as_ref().into(),
             self.anchor.as_ref().into(),
         );
 

--- a/lib/uniffi-zcash/tests/python/transaction.py
+++ b/lib/uniffi-zcash/tests/python/transaction.py
@@ -186,7 +186,7 @@ class OrchardTransactionBuilderTest(unittest.TestCase):
 
         builder = ZcashOrchardTransactionBuilder(ZcashConsensusParameters.MAIN_NETWORK, ZcashBlockHeight(2030820), ZcashBlockHeight(2030820+100), anchor, flags)
         builder.add_spend(fvk, note, merkle_path)
-        builder.add_output(ovk, address, 15, None)
+        builder.add_recipient(ovk, address, 15, None)
 
         transaction = builder.build([key.orchard()], [0]*32)
 

--- a/lib/uniffi-zcash/tests/python/transaction.py
+++ b/lib/uniffi-zcash/tests/python/transaction.py
@@ -182,8 +182,9 @@ class OrchardTransactionBuilderTest(unittest.TestCase):
 
 
         anchor = merkle_path.root(note.commitment().to_extracted_note_commitment())
+        flags = ZcashOrchardFlags.from_parts(True, True)
 
-        builder = ZcashOrchardTransactionBuilder(ZcashConsensusParameters.MAIN_NETWORK, ZcashBlockHeight(2030820), ZcashBlockHeight(2030820+100), anchor)
+        builder = ZcashOrchardTransactionBuilder(ZcashConsensusParameters.MAIN_NETWORK, ZcashBlockHeight(2030820), ZcashBlockHeight(2030820+100), anchor, flags)
         builder.add_spend(fvk, note, merkle_path)
         builder.add_output(ovk, address, 15, None)
 


### PR DESCRIPTION
This was hardcoded in the beginning while investigation, now its fixed.
